### PR TITLE
Fix issue with Traversal failing because OutputPath is not set

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,27 @@
+version: 1.0.{build}
+pull_requests:
+  do_not_increment_build_number: true
+skip_branch_with_pr: true
+image: Visual Studio 2017
+configuration: Release
+platform: Any CPU
+cache: '%USERPROFILE%\.nuget\packages'
+build_script:
+- cmd: >-
+    IF /I "%APPVEYOR_REPO_TAG%" EQU "TRUE" SET Configuration=Release
+
+    MSBuild MSBuildSdks.sln /Restore /NodeReuse:false /MaxCpuCount /ConsoleLoggerParameters:Verbosity=Minimal /BinaryLogger /Logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+artifacts:
+- path: msbuild.binlog
+  name: logs
+on_success:
+- ps: >-
+    if($env:APPVEYOR_REPO_TAG_NAME -ne $null) {
+      $split = $env:APPVEYOR_REPO_TAG_NAME.Split("-")
+      if($split.Length -eq 2) {
+        $packageName = $split[0]
+        $pattern = "$packageName*.nupkg"
+        Write-Host "Uploading artifacts that match $pattern"
+        Get-ChildItem -Path "." -Recurse -Filter $pattern | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+      }
+    }

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -167,6 +167,11 @@
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)" />
   </Target>
+  
+  <!--
+    Traversal projects do not build anything and should not check for invalid configuration/platform.
+  -->
+  <Target Name="_CheckForInvalidConfigurationAndPlatform" />
 
   <Import Project="$(CustomAfterTraversalTargets)" Condition=" '$(CustomAfterTraversalTargets)' != '' And Exists('$(CustomAfterTraversalTargets)') " />
 </Project>


### PR DESCRIPTION
We don't want traversal projects to build anything

* Add empty _CheckForInvalidConfigurationAndPlatform target
* Remove IncrementalClean since it needs OutDir to be set
* Add appveyor.yml