### PR TITLE
Remove IncrementalClean from Traversal

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -20,7 +20,6 @@
       PrepareForBuild;
       PreBuildEvent;
       ResolveReferences;
-      IncrementalClean;
       PostBuildEvent
     </CoreBuildDependsOn>
 


### PR DESCRIPTION
When Platform or Configuration are set, IncrementalClean fails

```
Microsoft.Common.CurrentVersion.targets(4841,5): error MSB4044:
 The "FindUnderPath" task was not given a value for the required parameter "Path". 
```