### PR TITLE
Minor improvements

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.17" PrivateAssets="All" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.1.23" PrivateAssets="All" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -18,5 +18,11 @@
     <PackageIconUrl>https://github.com/Microsoft/msbuild/raw/master/branding/MSBuild-NuGet-Icon.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/MSBuildSdks.git</RepositoryUrl>
   </PropertyGroup>
+  
+  <ItemDefinitionGroup>
+    <PackageReference>
+      <PrivateAssets>Compile</PrivateAssets>
+    </PackageReference>
+  </ItemDefinitionGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,9 +3,8 @@ pull_requests:
   do_not_increment_build_number: true
 skip_branch_with_pr: true
 image: Visual Studio 2017
-configuration: Release
+configuration: Debug
 platform: Any CPU
-cache: '%USERPROFILE%\.nuget\packages'
 build_script:
 - cmd: >-
     IF /I "%APPVEYOR_REPO_TAG%" EQU "TRUE" SET Configuration=Release
@@ -25,3 +24,5 @@ on_success:
         Get-ChildItem -Path "." -Recurse -Filter $pattern | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
       }
     }
+on_failure:
+- ps: Get-ChildItem .\*log -Recurse | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }

--- a/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
+++ b/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
@@ -6,7 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+    <PackageReference Include="Microsoft.Build" Version="15.7.179" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.7.179" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="MSBuild.ProjectCreation" Version="1.0.8" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
+++ b/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
@@ -6,7 +6,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.2" />
+    <PackageReference Include="Microsoft.Build" Version="15.7.179" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.7.179" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="MSBuild.ProjectCreation" Version="1.0.8" />
+    <PackageReference Include="Shouldly" Version="3.0.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/UnitTest.Common/UnitTest.Common.csproj
+++ b/src/UnitTest.Common/UnitTest.Common.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.7-preview-ge60d679b53" />
-    <PackageReference Include="MSBuild.ProjectCreation" Version="1.0.6" />
-    <PackageReference Include="Microsoft.Build" Version="15.6.82" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.Build.Framework" Version="15.6.82" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.13" />
+    <PackageReference Include="MSBuild.ProjectCreation" Version="1.0.8" />
+    <PackageReference Include="Microsoft.Build" Version="15.7.179" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="15.7.179" ExcludeAssets="runtime" />
     <PackageReference Include="Shouldly" Version="3.0.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />


### PR DESCRIPTION
* Disable transitive project-to-project compile-time dependency of package references
* Update package reference versions to latest
* Change appveyor.yml to only upload logs on failure
* Change appveyor.yml to not cache restored packages