### PR TITLE
Remove -preview from versions and public release spec

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -49,23 +49,5 @@
       </NuspecProperties>
     </PropertyGroup>
   </Target>
-  
-  <!--
-    Removes the prerelease version when $(PublicRelease) is true.  This allows us to have -preview in the version.json for local
-    unreleased builds.  When we create a tag for a particular SDK, then PublicRelease is 'true' and the -preview is dropped.
-  -->
-  <Target Name="GetBuildVersionEx" AfterTargets="GetBuildVersion" BeforeTargets="SetCloudBuildVersionVars" DependsOnTargets="GetBuildVersion" Condition=" '$(PublicRelease)' == 'true' ">
-    <PropertyGroup>
-      <PrereleaseVersion></PrereleaseVersion>
-      <AssemblyInformationalVersion>$(BuildVersionSimple)$(SemVerBuildSuffix)</AssemblyInformationalVersion>
-      <CloudBuildNumber>$(BuildVersionSimple)</CloudBuildNumber>
-      <NuGetPackageVersion>$(BuildVersionSimple)</NuGetPackageVersion>
-      <PackageVersion>$(BuildVersionSimple)</PackageVersion>
-      <NPMPackageVersion>$(BuildVersionSimple)</NPMPackageVersion>
-    </PropertyGroup>
-    <ItemGroup>
-      <CloudBuildVersionVars GitAssemblyInformationalVersion="$(AssemblyInformationalVersion)"/>
-    </ItemGroup>
-  </Target>
 
 </Project>

--- a/src/CentralPackageVersions/version.json
+++ b/src/CentralPackageVersions/version.json
@@ -1,7 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "1.0-preview",
-  "publicReleaseRefSpec": [
-    "^refs/tags/Microsoft\\.Build\\.CentralPackageVersions-v\\d+\\.\\d+.\\d+"
-  ]
+  "version": "1.0"
 }

--- a/src/NoTargets/version.json
+++ b/src/NoTargets/version.json
@@ -1,7 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "1.0-preview",
-  "publicReleaseRefSpec": [
-    "^refs/tags/Microsoft\\.Build\\.NoTargets-v\\d+\\.\\d+.\\d+"
-  ]
+  "version": "1.0"
 }

--- a/src/Traversal/version.json
+++ b/src/Traversal/version.json
@@ -1,7 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "1.0-preview",
-  "publicReleaseRefSpec": [
-    "^refs/tags/Microsoft\\.Build\\.Traversal-v\\d+\\.\\d+.\\d+"
-  ]
+  "version": "1.0"
 }


### PR DESCRIPTION
Since publicReleaseRefSpec is checked in, its impossible to build past commits that automatically determine if the release is public.  So there's no good way to actually include this.  It will be set by official builds instead.