### PR TITLE
Fixes issues related to SDK-style projects and non-existent targets

### DIFF
--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -2,9 +2,12 @@
 //
 // Licensed under the MIT license.
 
+using Microsoft.Build.Evaluation;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities.ProjectCreation;
 using Shouldly;
+using System;
+using System.Collections.Generic;
 using System.Linq;
 using UnitTest.Common;
 using Xunit;
@@ -13,7 +16,7 @@ namespace Microsoft.Build.Traversal.UnitTests
 {
     public class TraversalTests : MSBuildSdkTestBase
     {
-        [Fact(Skip = "This does not currently work, need to investigate why")]
+        [Fact]
         public void SkipsNonExistentTargets()
         {
             string[] projects = new[]
@@ -35,6 +38,7 @@ namespace Microsoft.Build.Traversal.UnitTests
         }
 
         [Theory]
+        [InlineData("Clean")]
         [InlineData("Build")]
         [InlineData("Test")]
         public void TraversalTargetsRun(string target)
@@ -42,10 +46,8 @@ namespace Microsoft.Build.Traversal.UnitTests
             string[] projects = new[]
             {
                 ProjectCreator.Templates.LogsMessage("BF0C6E1044514FE3AE4B78EC308D6F45", MessageImportance.High, targetName: target, path: GetTempFileWithExtension(".proj"))
-                    .Target("GetNativeManifest")
                     .Save(),
                 ProjectCreator.Templates.LogsMessage("40869F4000B44D75A52AB305F24E0FDB", MessageImportance.High, targetName: target, path: GetTempFileWithExtension(".proj"))
-                    .Target("GetNativeManifest")
                     .Save(),
             }.Select(i => i.FullPath).ToArray();
 
@@ -71,6 +73,41 @@ namespace Microsoft.Build.Traversal.UnitTests
                     },
                     ignoreOrder: true,
                     customMessage: () => buildOutput.GetConsoleLog());
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Debug")]
+        [InlineData("Release")]
+        [InlineData("Random")]
+        public void WorksWhenConfigurationSpecified(string configuration)
+        {
+            Dictionary<string, string> globalProperties = new Dictionary<string, string>
+            {
+                ["DesignTimeBuild"] = "true"
+            };
+
+            if (!String.IsNullOrWhiteSpace(configuration))
+            {
+                globalProperties.Add("Configuration", configuration);
+            }
+
+            string[] projects = new[]
+            {
+                ProjectCreator.Templates.SdkCsproj(path: GetTempFileWithExtension(".csproj"))
+                    .Save(),
+            }.Select(i => i.FullPath).ToArray();
+
+            ProjectCreator
+                .Templates
+                .TraversalProject(
+                    projects,
+                    path: GetTempFile("dirs.proj"),
+                    projectCollection: new ProjectCollection(globalProperties))
+                .Save()
+                .TryBuild("Clean", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(customMessage: () => buildOutput.GetConsoleLog());
         }
     }
 }

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -8,6 +8,16 @@
 
   <Import Project="$(CustomBeforeTraversalTargets)" Condition=" '$(CustomBeforeTraversalTargets)' != '' And Exists('$(CustomBeforeTraversalTargets)') " />
 
+  <PropertyGroup Condition=" '$(OutputPath)' == '' ">
+    <!--
+      OutputPath is required to be set because targets like Clean will read it.  Traversal projects shouldn't really emit any
+      output but it could be hard to track down all of the places where $(OutputPath) and $(OutDir) are expected to be set.
+    -->
+    <OutputPath Condition=" '$(Configuration)' == '' And '$(Platform)' == '' ">bin\Debug\</OutputPath>
+    <OutputPath Condition=" '$(Configuration)' != '' And '$(Platform)' == '' ">bin\$(Configuration)\</OutputPath>
+    <OutputPath Condition=" '$(Configuration)' != '' And '$(Platform)' != '' ">bin\$(Configuration)\$(Platform)\</OutputPath>
+  </PropertyGroup>
+  
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition=" Exists('$(MSBuildToolsPath)\Microsoft.Common.targets') " />
 
   <PropertyGroup>
@@ -36,6 +46,15 @@
     <TestDependsOn>
       Build
     </TestDependsOn>
+
+    <CleanDependsOn>
+      BeforeClean;
+      UnmanagedUnregistration;
+      CoreClean;
+      PrepareProjectReferences;
+      CleanPublishFolder;
+      AfterClean
+    </CleanDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TraversalTranslateProjectFileItems)' != 'false' ">


### PR DESCRIPTION
Always set OutputPath so that targets that require it (like Clean) are happy.

Specify the list of targets in CleanDependsOn to disable the stock clean target.

Fixes #35