### PR TITLE
Fixed Microsoft.Common.targets import

### DIFF
--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -6,6 +6,15 @@
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!--
+    Setup LanguageTargets to include Microsoft.Common.targets
+    Normally Microsoft.Common.targets is imported via the Language specific targets, but the 
+    NoTargets SDK does not have any "language", so we import the common targets directly
+  -->
+  <PropertyGroup>
+    <LanguageTargets Condition="'$(LanguageTargets)' == ''">$(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
+  </PropertyGroup>
+
   <Import Project="$(CustomBeforeNoTargets)" Condition="'$(CustomBeforeNoTargets)' != '' and Exists('$(CustomBeforeNoTargets)')" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />


### PR DESCRIPTION
Microsoft.Common.targets was not imported into NoTargets SDK projects (#42),
resulting in some functionality like Nuget build extensions (#41) and
Directory.Build.targets (#40 ) not working correctly.

Fixes #40 
Fixes #41 
Fixes #42