### PR TITLE
Make IsTraversal property determination case-insensitive.

### DIFF
--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -16,6 +16,40 @@ namespace Microsoft.Build.Traversal.UnitTests
 {
     public class TraversalTests : MSBuildSdkTestBase
     {
+        [Theory]
+        [InlineData("dirs.proj")]
+        [InlineData("Dirs.proj")]
+        [InlineData("Dirs.Proj")]
+        [InlineData("DiRs.PrOj")]
+        public void IsTraversalPropertyCaseInsensitive(string projectName)
+        {
+            ProjectCreator
+                .Templates
+                .TraversalProject(
+                    new string[0],
+                    path: GetTempFile(projectName))
+                .Save()
+                .TryGetPropertyValue("IsTraversal", out string isTraversal);
+
+            isTraversal.ShouldBe("true", StringCompareShould.IgnoreCase);
+        }
+
+        [Theory]
+        [InlineData("dirs.proj", "true")]
+        [InlineData("asdf.proj", "")]
+        public void IsTraversalPropertySetCorrectly(string projectName, string expectedValue)
+        {
+            ProjectCreator
+                .Templates
+                .TraversalProject(
+                    new string[0],
+                    path: GetTempFile(projectName))
+                .Save()
+                .TryGetPropertyValue("IsTraversal", out string isTraversal);
+
+            isTraversal.ShouldBe(expectedValue, StringCompareShould.IgnoreCase);
+        }
+
         [Fact]
         public void SkipsNonExistentTargets()
         {

--- a/src/Traversal/Sdk/Sdk.props
+++ b/src/Traversal/Sdk/Sdk.props
@@ -19,7 +19,7 @@
     <TraversalProjectNames Condition=" '$(TraversalProjectNames)' == '' ">dirs.proj</TraversalProjectNames>
 
     <IsTraversal Condition=" '$(IsTraversal)' != '' ">$([System.Convert]::ToBoolean($(IsTraversal)))</IsTraversal>
-    <IsTraversal Condition=" '$(IsTraversal)' == '' And $(TraversalProjectNames.Contains($(MSBuildProjectFile))) ">true</IsTraversal>
+    <IsTraversal Condition=" '$(IsTraversal)' == '' And $(TraversalProjectNames.IndexOf($(MSBuildProjectFile), System.StringComparison.OrdinalIgnoreCase)) >= 0 ">true</IsTraversal>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(TraversalDoNotReferenceOutputAssemblies)' != 'false' ">


### PR DESCRIPTION
`String.Contains()` is case sensitive and has no overload so switch to `String.IndexOf(String, StringComparison)` instead.

Also added unit tests

Fixes #46