### PR TITLE
Add support for command `dotnet test` and `dotnet publish`

### DIFF
--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -75,7 +75,9 @@ namespace Microsoft.Build.Traversal.UnitTests
         [InlineData("Clean")]
         [InlineData("Build")]
         [InlineData("Test")]
+        [InlineData("VSTest")]
         [InlineData("Pack")]
+        [InlineData("Publish")]
         public void TraversalTargetsRun(string target)
         {
             string[] projects = new[]

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -63,6 +63,10 @@
     <PackDependsOn>
       ResolveReferences;
     </PackDependsOn>
+
+    <PublishDependsOn>
+      Build;
+    </PublishDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TraversalTranslateProjectFileItems)' != 'false' ">
@@ -292,6 +296,49 @@
 
     <MSBuild Projects="@(PostTraversalProject)"
              Targets="Pack"
+             Properties="$(PostTraversalGlobalProperties)"
+             Condition=" '@(PostTraversalProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+  </Target>
+
+  <Target Name="Publish"
+          DependsOnTargets="$(PublishDependsOn)">
+
+    <MSBuild Projects="@(PreTraversalProject)"
+             Targets="Publish"
+             Properties="$(PreTraversalGlobalProperties)"
+             Condition=" '@(PreTraversalProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PreTraversalPublishProject)"
+             Targets="Publish"
+             Properties="$(PreTraversalPublishGlobalProperties)"
+             Condition=" '@(PreTraversalPublishProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
+             Targets="Publish"
+             Properties="$(TraversalGlobalProperties);$(TraversalPublishGlobalProperties)"
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PostTraversalPublishProject)"
+             Targets="Publish"
+             Properties="$(PostTraversalPublishGlobalProperties)"
+             Condition=" '@(PostTraversalPublishProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PostTraversalProject)"
+             Targets="Publish"
              Properties="$(PostTraversalGlobalProperties)"
              Condition=" '@(PostTraversalProject)' != '' "
              BuildInParallel="$(BuildInParallel)"

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright (c) Microsoft Corporation. All rights reserved.
-  
+
   Licensed under the MIT license.
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -17,7 +17,7 @@
     <OutputPath Condition=" '$(Configuration)' != '' And '$(Platform)' == '' ">bin\$(Configuration)\</OutputPath>
     <OutputPath Condition=" '$(Configuration)' != '' And '$(Platform)' != '' ">bin\$(Configuration)\$(Platform)\</OutputPath>
   </PropertyGroup>
-  
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition=" Exists('$(MSBuildToolsPath)\Microsoft.Common.targets') " />
 
   <PropertyGroup>
@@ -46,6 +46,10 @@
     <TestDependsOn>
       Build
     </TestDependsOn>
+
+    <VSTestDependsOn>
+      Build
+    </VSTestDependsOn>
 
     <CleanDependsOn>
       BeforeClean;
@@ -209,6 +213,49 @@
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />
   </Target>
 
+  <Target Name="VSTest"
+          DependsOnTargets="$(VSTestDependsOn)">
+
+    <MSBuild Projects="@(PreTraversalProject)"
+             Targets="VSTest"
+             Properties="$(PreTraversalGlobalProperties)"
+             Condition=" '@(PreTraversalProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PreTraversalVSTestProject)"
+             Targets="VSTest"
+             Properties="$(PreTraversalVSTestGlobalProperties)"
+             Condition=" '@(PreTraversalVSTestProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
+             Targets="VSTest"
+             Properties="$(TraversalGlobalProperties);$(TraversalVSTestGlobalProperties)"
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PostTraversalVSTestProject)"
+             Targets="VSTest"
+             Properties="$(PostTraversalVSTestGlobalProperties)"
+             Condition=" '@(PostTraversalVSTestProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+
+    <MSBuild Projects="@(PostTraversalProject)"
+             Targets="VSTest"
+             Properties="$(PostTraversalGlobalProperties)"
+             Condition=" '@(PostTraversalProject)' != '' "
+             BuildInParallel="$(BuildInParallel)"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+  </Target>
+
   <Target Name="Pack"
           DependsOnTargets="$(PackDependsOn)">
 
@@ -251,7 +298,7 @@
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />
   </Target>
-  
+
   <!--
     Traversal projects do not build anything and should not check for invalid configuration/platform.
   -->


### PR DESCRIPTION
This change enables this sdk to execute `VSTest` target and `Publish` in referenced project.

However, If a dotnet project is not a test project, it will also has a `VSTest` target, which will lead to a build error. Maybe need to add some switch to control it.