### PR TITLE
Packages.props is actually located using GetPathOfFileAbove

### DIFF
--- a/src/CentralPackageVersions/README.md
+++ b/src/CentralPackageVersions/README.md
@@ -99,7 +99,7 @@ Setting the following properties control how Central Package Versions works.
 
 | Property                            | Description |
 |-------------------------------------|-------------|
-| `CentralPackagesFile `  | The full path to the file containing your package versions.  Defaults to `Packages.props` at the root of your repository. |
+| `CentralPackagesFile `  | The full path to the file containing your package versions.  Defaults to the first `Packages.props` file found in the current directory or any of its ancestors. |
 | `CustomBeforeCentralPackageVersionsProps`    | A list of custom MSBuild projects to import **before** central package version properties are declared.|
 | `CustomAfterCentralPackageVersionsProps`    | A list of custom MSBuild projects to import **after** central package version properties are declared.|
 | `CustomBeforeCentralPackageVersionsTargets`    | A list of custom MSBuild projects to import **before** central package version targets are declared.|

--- a/src/CentralPackageVersions/README.md
+++ b/src/CentralPackageVersions/README.md
@@ -99,7 +99,7 @@ Setting the following properties control how Central Package Versions works.
 
 | Property                            | Description |
 |-------------------------------------|-------------|
-| `CentralPackagesFile `  | The full path to the file containing your package versions.  Defaults to the first `Packages.props` file found in the current directory or any of its ancestors. |
+| `CentralPackagesFile `  | The full path to the file containing your package versions.  Defaults to the first `Packages.props` file found in the current directory or any of its ancestors. It is recommended that you place your version file at the root of your repository so it is shared by all projects and is easy to locate. You should only set this property if you want to use a custom path. |
 | `CustomBeforeCentralPackageVersionsProps`    | A list of custom MSBuild projects to import **before** central package version properties are declared.|
 | `CustomAfterCentralPackageVersionsProps`    | A list of custom MSBuild projects to import **after** central package version properties are declared.|
 | `CustomBeforeCentralPackageVersionsTargets`    | A list of custom MSBuild projects to import **before** central package version targets are declared.|


### PR DESCRIPTION
The traversal is done using [GetPathOfFileAbove](https://docs.microsoft.com/en-us/visualstudio/msbuild/property-functions?view=vs-2017#msbuild-getpathoffileabove) so the file can be located anywhere in the source tree, not necessarily the repository root. 

The logic is similar to how `Directory.Build.props` is located.