### PR TITLE
Use ResolveReferences instead of just ResolveProjectReferences

### DIFF
--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -35,7 +35,7 @@
       BuildOnlySettings;
       PrepareForBuild;
       PreBuildEvent;
-      ResolveProjectReferences;
+      ResolveReferences;
       GetTargetPath;
       PrepareForRun;
       IncrementalClean;


### PR DESCRIPTION
ResolveReferences runs a few other targets that harvest CopyLocal references.  When just running ResolveProjectReferences, dependent projects don't get all of the outputs.