### PR TITLE
Set UsingMicrosoftNoTargetsSdk property

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -7,7 +7,6 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities.ProjectCreation;
 using Shouldly;
 using System.Collections.Generic;
-using System.Linq;
 using UnitTest.Common;
 using Xunit;
 
@@ -36,6 +35,16 @@ namespace Microsoft.Build.NoTargets.UnitTests
             result.ShouldBeTrue(() => buildOutput.GetConsoleLog());
 
             buildOutput.Messages.High.ShouldContain("86F00AF59170450E9D687652D74A6394");
+        }
+
+        [Fact]
+        public void UsingMicrosoftNoTargetsSdkValueSet()
+        {
+            ProjectCreator.Templates.NoTargetsProject(
+                path: GetTempFileWithExtension(".csproj"))
+                .TryGetPropertyValue("UsingMicrosoftNoTargetsSdk", out string propertyValue);
+
+            propertyValue.ShouldBe("true");
         }
     }
 }

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -6,6 +6,10 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <UsingMicrosoftNoTargetsSdk>true</UsingMicrosoftNoTargetsSdk>
+  </PropertyGroup>
+
   <Import Project="$(CustomBeforeNoTargetsProps)" Condition=" '$(CustomBeforeNoTargetsProps)' != '' And Exists('$(CustomBeforeNoTargetsProps)') " />
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>


### PR DESCRIPTION
This allows users to key off of the property for other build logic.