### PR TITLE
Add new Artifacts logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,7 @@ dlldata.c
 # .NET Core
 project.lock.json
 project.fragment.lock.json
-artifacts/
+/artifacts
 **/Properties/launchSettings.json
 
 *_i.c

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <DefaultItemExcludes>*log</DefaultItemExcludes>
     <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+    <LangVersion>Latest</LangVersion>
 
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>

--- a/MSBuildSdks.sln
+++ b/MSBuildSdks.sln
@@ -1,13 +1,12 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.27329.0
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.28801.201
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.Traversal", "src\Traversal\Microsoft.Build.Traversal.csproj", "{B93918D4-75EA-467E-8F50-393A1324FF91}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DC479DC1-DD8C-4DBA-AA37-FC3D39F24266}"
 	ProjectSection(SolutionItems) = preProject
-		appveyor.yml = appveyor.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.rsp = Directory.Build.rsp
 		Directory.Build.targets = Directory.Build.targets
@@ -42,6 +41,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "NoTargets", "NoTargets", "{
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleNoTargets", "samples\NoTargets\SampleNoTargets\SampleNoTargets.csproj", "{48F56A6B-A285-4B40-9E96-044F7AA2C532}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.Artifacts", "src\Artifacts\Microsoft.Build.Artifacts.csproj", "{6E84BA77-308F-4780-852F-B27F8BFD2797}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Artifacts.UnitTests", "src\Artifacts.UnitTests\Microsoft.Build.Artifacts.UnitTests.csproj", "{359B2C2B-B9B8-496F-B4B1-9E4359729F89}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -81,6 +84,14 @@ Global
 		{48F56A6B-A285-4B40-9E96-044F7AA2C532}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48F56A6B-A285-4B40-9E96-044F7AA2C532}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48F56A6B-A285-4B40-9E96-044F7AA2C532}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6E84BA77-308F-4780-852F-B27F8BFD2797}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6E84BA77-308F-4780-852F-B27F8BFD2797}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6E84BA77-308F-4780-852F-B27F8BFD2797}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6E84BA77-308F-4780-852F-B27F8BFD2797}.Release|Any CPU.Build.0 = Release|Any CPU
+		{359B2C2B-B9B8-496F-B4B1-9E4359729F89}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{359B2C2B-B9B8-496F-B4B1-9E4359729F89}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{359B2C2B-B9B8-496F-B4B1-9E4359729F89}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{359B2C2B-B9B8-496F-B4B1-9E4359729F89}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Packages.props
+++ b/Packages.props
@@ -12,6 +12,7 @@
     <PackageReference Update="MicroBuild.Core" Version="0.3.0" />
     <PackageReference Update="Microsoft.Build" Version="15.9.20" />
     <PackageReference Update="Microsoft.Build.Framework" Version="15.9.20" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="15.9.20" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Update="MSBuild.ProjectCreation" Version="1.2.10" />
     <PackageReference Update="Shouldly" Version="3.0.2" />

--- a/build/Sign.proj
+++ b/build/Sign.proj
@@ -18,15 +18,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\src\CentralPackageVersions\Microsoft.Build.CentralPackageVersions.csproj"  OutputItemType="ProjectOutput" Targets="Pack;_GetOutputItemsFromPack" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\src\NoTargets\Microsoft.Build.NoTargets.csproj" OutputItemType="ProjectOutput" Targets="Pack;_GetOutputItemsFromPack" ReferenceOutputAssembly="false" />
-    <ProjectReference Include="..\src\Traversal\Microsoft.Build.Traversal.csproj" OutputItemType="ProjectOutput" Targets="Pack;_GetOutputItemsFromPack" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\src\Artifacts\Microsoft.Build.Artifacts.csproj" OutputItemType="AssemblyOutput" Targets="GetTargetPath" SetTargetFramework="TargetFramework=net46" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\src\Artifacts\Microsoft.Build.Artifacts.csproj" OutputItemType="AssemblyOutput" Targets="GetTargetPath" SetTargetFramework="TargetFramework=netcoreapp2.1" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\src\Artifacts\Microsoft.Build.Artifacts.csproj" OutputItemType="PackageOutput" Targets="Pack;_GetOutputItemsFromPack" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\src\CentralPackageVersions\Microsoft.Build.CentralPackageVersions.csproj"  OutputItemType="PackageOutput" Targets="Pack;_GetOutputItemsFromPack" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\src\NoTargets\Microsoft.Build.NoTargets.csproj" OutputItemType="PackageOutput" Targets="Pack;_GetOutputItemsFromPack" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\src\Traversal\Microsoft.Build.Traversal.csproj" OutputItemType="PackageOutput" Targets="Pack;_GetOutputItemsFromPack" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
   <Target Name="StageArtifacts"
           BeforeTargets="AfterBuild">
     <ItemGroup>
-      <Artifact Include="@(ProjectOutput)" Authenticode="NuGet" Condition=" '%(Extension)' == '.nupkg' " />
+      <FilesToSign Include="@(AssemblyOutput)" Authenticode="Microsoft" StrongName="StrongName" />
+      <Artifact Include="@(PackageOutput)" Authenticode="NuGet" Condition=" '%(Extension)' == '.nupkg' " />
     </ItemGroup>
 
     <Copy SourceFiles="@(Artifact->Distinct())"

--- a/src/Artifacts.UnitTests/ArtifactsTests.cs
+++ b/src/Artifacts.UnitTests/ArtifactsTests.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Utilities.ProjectCreation;
+using Shouldly;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using UnitTest.Common;
+using Xunit;
+
+namespace Microsoft.Build.Artifacts.UnitTests
+{
+    public class ArtifactsTests : MSBuildSdkTestBase
+    {
+        [Fact]
+        public void BackCompatWithRobocopyItems()
+        {
+            DirectoryInfo outputPath = CreateFiles(
+                "bin",
+                "foo.exe",
+                "foo.pdb",
+                "foo.exe.config",
+                "bar.dll",
+                "bar.pdb",
+                "bar.cs");
+
+            DirectoryInfo distribPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
+
+            ProjectCreator.Templates.ProjectWithArtifacts(
+                    outputPath: outputPath.FullName)
+                .ItemRobocopy(outputPath.FullName, distribPath.FullName, "*exe *dll *exe.config")
+                .TryBuild(out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            distribPath.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    "bar.dll",
+                    "foo.exe",
+                    "foo.exe.config",
+                }.Select(i => Path.Combine(distribPath.FullName, i)));
+        }
+
+        [Fact]
+        public void CanOverrideDefaultArtifactsSourcePath()
+        {
+            string customPath = Path.Combine(TestRootPath, "custom");
+
+            string artifactsPath = Path.Combine(TestRootPath, "artifacts");
+
+            ProjectCreator.Templates.ProjectWithArtifacts(
+                    artifactsPath: artifactsPath)
+                .Property("DefaultArtifactsSource", customPath)
+                .TryGetItems("Artifacts", out IReadOnlyCollection<ProjectItem> artifactItems);
+
+            ProjectItem artifactItem = artifactItems.ShouldHaveSingleItem();
+
+            artifactItem.EvaluatedInclude.ShouldBe(customPath);
+            artifactItem.GetMetadataValue("DestinationFolder").ShouldBe(artifactsPath);
+        }
+
+        [Fact]
+        public void DefaultArtifactsUseOutputPath()
+        {
+            DirectoryInfo outputPath = CreateFiles(
+                "bin",
+                "foo.exe",
+                "foo.pdb",
+                "foo.exe.config",
+                "bar.dll",
+                "bar.pdb",
+                "bar.cs");
+
+            DirectoryInfo artifactsPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
+
+            ProjectCreator.Templates.ProjectWithArtifacts(
+                outputPath: outputPath.FullName,
+                artifactsPath: artifactsPath.FullName)
+                .TryGetItems("Artifacts", out IReadOnlyCollection<ProjectItem> artifactItems)
+                .TryBuild(out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            ProjectItem artifactItem = artifactItems.ShouldHaveSingleItem();
+
+            artifactItem.EvaluatedInclude.ShouldBe(outputPath.FullName);
+            artifactItem.GetMetadataValue("DestinationFolder").ShouldBe(artifactsPath.FullName);
+
+            artifactsPath.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    "bar.dll",
+                    "foo.exe",
+                    "foo.exe.config",
+                }.Select(i => Path.Combine(artifactsPath.FullName, i)));
+        }
+
+        [Fact]
+        public void UsingSdkLogic()
+        {
+            DirectoryInfo outputPath = CreateFiles(
+                "bin",
+                "foo.exe",
+                "foo.pdb",
+                "foo.exe.config",
+                "bar.dll",
+                "bar.pdb",
+                "bar.cs");
+
+            DirectoryInfo artifactsPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
+
+            ProjectCreator.Templates.SdkProjectWithArtifacts(
+                    outputPath: outputPath.FullName,
+                    artifactsPath: artifactsPath.FullName)
+                .TryGetItems("Artifacts", out IReadOnlyCollection<ProjectItem> artifactItems)
+                .TryBuild(out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            ProjectItem artifactItem = artifactItems.ShouldHaveSingleItem();
+
+            artifactItem.EvaluatedInclude.ShouldBe(outputPath.FullName);
+            artifactItem.GetMetadataValue("DestinationFolder").ShouldBe(artifactsPath.FullName);
+
+            artifactsPath.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    "bar.dll",
+                    "foo.exe",
+                    "foo.exe.config",
+                }.Select(i => Path.Combine(artifactsPath.FullName, i)));
+        }
+    }
+}

--- a/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
@@ -11,7 +11,8 @@ namespace Microsoft.Build.Artifacts.UnitTests
 {
     internal static class CustomProjectCreatorTemplates
     {
-        private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(CustomProjectCreatorTemplates).Assembly.Location);
+        private static readonly string CurrentDirectory = Environment.CurrentDirectory;
+        private static readonly string ArtifactsTaskAssembly = Path.Combine(CurrentDirectory, "Microsoft.Build.Artifacts.dll");
 
         public static ProjectCreator ProjectWithArtifacts(
             this ProjectCreatorTemplates templates,
@@ -36,14 +37,14 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     treatAsLocalProperty,
                     projectCollection,
                     projectFileOptions)
-                .Property("ArtifactsTaskAssembly", Path.Combine(ThisAssemblyDirectory, "Microsoft.Build.Artifacts.dll"))
-                .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.props"))
+                .Property("ArtifactsTaskAssembly", ArtifactsTaskAssembly)
+                .Import(Path.Combine(CurrentDirectory, "build", "Microsoft.Build.Artifacts.props"))
                 .Property("OutputPath", outputPath)
                 .Property("ArtifactsPath", artifactsPath)
                 .CustomAction(customAction)
                 .Target("Build")
                 .Target("AfterBuild", afterTargets: "Build")
-                .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.targets"));
+                .Import(Path.Combine(CurrentDirectory, "build", "Microsoft.Build.Artifacts.targets"));
         }
 
         public static ProjectCreator SdkProjectWithArtifacts(
@@ -69,14 +70,14 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     treatAsLocalProperty,
                     projectCollection,
                     projectFileOptions)
-                .Property("ArtifactsTaskAssembly", Path.Combine(ThisAssemblyDirectory, "Microsoft.Build.Artifacts.dll"))
-                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.props"))
+                .Property("ArtifactsTaskAssembly", ArtifactsTaskAssembly)
+                .Import(Path.Combine(CurrentDirectory, "Sdk", "Sdk.props"))
                 .Property("OutputPath", outputPath)
                 .Property("ArtifactsPath", artifactsPath)
                 .CustomAction(customAction)
                 .Target("Build")
                 .Target("AfterBuild", afterTargets: "Build")
-                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.targets"));
+                .Import(Path.Combine(CurrentDirectory, "Sdk", "Sdk.targets"));
         }
     }
 }

--- a/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Utilities.ProjectCreation;
+using System;
+using System.IO;
+
+namespace Microsoft.Build.Artifacts.UnitTests
+{
+    internal static class CustomProjectCreatorTemplates
+    {
+        private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(CustomProjectCreatorTemplates).Assembly.Location);
+
+        public static ProjectCreator ProjectWithArtifacts(
+            this ProjectCreatorTemplates templates,
+            string outputPath = null,
+            string artifactsPath = null,
+            Action<ProjectCreator> customAction = null,
+            string path = null,
+            string defaultTargets = null,
+            string initialTargets = null,
+            string sdk = null,
+            string toolsVersion = null,
+            string treatAsLocalProperty = null,
+            ProjectCollection projectCollection = null,
+            NewProjectFileOptions? projectFileOptions = null)
+        {
+            return ProjectCreator.Create(
+                    path,
+                    defaultTargets,
+                    initialTargets,
+                    sdk,
+                    toolsVersion,
+                    treatAsLocalProperty,
+                    projectCollection,
+                    projectFileOptions)
+                .Property("ArtifactsTaskAssembly", Path.Combine(ThisAssemblyDirectory, "Microsoft.Build.Artifacts.dll"))
+                .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.props"))
+                .Property("OutputPath", outputPath)
+                .Property("ArtifactsPath", artifactsPath)
+                .CustomAction(customAction)
+                .Target("Build")
+                .Target("AfterBuild", afterTargets: "Build")
+                .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.targets"));
+        }
+
+        public static ProjectCreator SdkProjectWithArtifacts(
+            this ProjectCreatorTemplates templates,
+            string outputPath = null,
+            string artifactsPath = null,
+            Action<ProjectCreator> customAction = null,
+            string path = null,
+            string defaultTargets = null,
+            string initialTargets = null,
+            string sdk = null,
+            string toolsVersion = null,
+            string treatAsLocalProperty = null,
+            ProjectCollection projectCollection = null,
+            NewProjectFileOptions? projectFileOptions = null)
+        {
+            return ProjectCreator.Create(
+                    path,
+                    defaultTargets,
+                    initialTargets,
+                    sdk,
+                    toolsVersion,
+                    treatAsLocalProperty,
+                    projectCollection,
+                    projectFileOptions)
+                .Property("ArtifactsTaskAssembly", Path.Combine(ThisAssemblyDirectory, "Microsoft.Build.Artifacts.dll"))
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.props"))
+                .Property("OutputPath", outputPath)
+                .Property("ArtifactsPath", artifactsPath)
+                .CustomAction(customAction)
+                .Target("Build")
+                .Target("AfterBuild", afterTargets: "Build")
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.targets"));
+        }
+    }
+}

--- a/src/Artifacts.UnitTests/ExtensionsMethods.cs
+++ b/src/Artifacts.UnitTests/ExtensionsMethods.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Utilities.ProjectCreation;
+using System.Collections.Generic;
+
+namespace Microsoft.Build.Artifacts.UnitTests
+{
+    internal static class ExtensionsMethods
+    {
+        public static ProjectCreator ItemArtifact(this ProjectCreator creator, string include, string destinationFolder, string fileMatch, string condition = null)
+        {
+            return creator.ItemInclude(
+                "Artifacts",
+                include,
+                null,
+                new Dictionary<string, string>
+                {
+                    { "DestinationFolder", destinationFolder },
+                    { "FileMatch", fileMatch }
+                },
+                condition);
+        }
+
+        public static ProjectCreator ItemRobocopy(this ProjectCreator creator, string include, string destinationFolder, string fileMatch, string condition = null)
+        {
+            return creator.ItemInclude(
+                "Robocopy",
+                include,
+                null,
+                new Dictionary<string, string>
+                {
+                    { "DestinationFolder", destinationFolder },
+                    { "FileMatch", fileMatch }
+                },
+                condition);
+        }
+    }
+}

--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net46</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="MSBuild.ProjectCreation" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Artifacts\Microsoft.Build.Artifacts.csproj" />
+    <ProjectReference Include="..\UnitTest.Common\UnitTest.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\Artifacts\build\**"
+          Link="build\%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\Artifacts\buildCrossTargeting\**"
+          Link="buildCrossTargeting\%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\Artifacts\Sdk\**"
+          Link="Sdk\%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+</Project>

--- a/src/Artifacts.UnitTests/RobocopyTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyTests.cs
@@ -1,0 +1,209 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Artifacts.Tasks;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities.ProjectCreation;
+using Shouldly;
+using System.IO;
+using System.Linq;
+using UnitTest.Common;
+using Xunit;
+
+namespace Microsoft.Build.Artifacts.UnitTests
+{
+    public class RobocopyTests : MSBuildSdkTestBase
+    {
+        [Fact]
+        public void NonRecursiveWildcards()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt",
+                @"foo.ini",
+                @"bar.txt",
+                @"bar\bar.pdb",
+                @"bar\bar.txt",
+                @"bar.cs",
+                @"baz\baz.dll",
+                @"baz\baz.txt");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(source.FullName)
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                        ["FileMatch"] = "*txt",
+                        [nameof(RobocopyMetadata.IsRecursive)] = "false"
+                    }
+                },
+                Sleep = duration => { }
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+
+            destination.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    "bar.txt",
+                    "foo.txt",
+                }.Select(i => Path.Combine(destination.FullName, i)));
+        }
+
+        [Fact]
+        public void RecursiveWildcards()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt",
+                @"foo.exe",
+                @"foo.exe.config",
+                @"foo.dll",
+                @"foo.pdb",
+                @"foo.xml",
+                @"foo.cs",
+                @"foo.ini",
+                @"bar.dll",
+                @"bar.pdb",
+                @"bar.xml",
+                @"bar.cs",
+                @"baz\baz.dll");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(source.FullName)
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                        ["FileMatch"] = "*exe *dll *exe.config"
+                    }
+                },
+                Sleep = duration => { }
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+
+            destination.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    "bar.dll",
+                    "foo.dll",
+                    "foo.exe",
+                    "foo.exe.config",
+                    @"baz\baz.dll"
+                }.Select(i => Path.Combine(destination.FullName, i)));
+        }
+
+        [Fact]
+        public void SingleFileMatch()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt",
+                @"foo.exe",
+                @"foo.exe.config",
+                @"foo.dll",
+                @"foo.pdb",
+                @"foo.xml",
+                @"foo.cs",
+                @"foo.ini",
+                @"bar.dll",
+                @"bar.pdb",
+                @"bar.xml",
+                @"bar.cs",
+                @"baz\baz.dll");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(source.FullName)
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                        ["FileMatch"] = "foo.pdb"
+                    }
+                },
+                Sleep = duration => { }
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+
+            destination.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    "foo.pdb",
+                }.Select(i => Path.Combine(destination.FullName, i)));
+        }
+
+        [Fact]
+        public void SingleFileMatchRecursive()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt",
+                @"foo.exe",
+                @"foo.exe.config",
+                @"foo.dll",
+                @"foo.pdb",
+                @"foo.xml",
+                @"foo.cs",
+                @"foo.ini",
+                @"bar.dll",
+                @"bar.pdb",
+                @"bar.xml",
+                @"bar.cs",
+                @"baz\baz.dll",
+                @"foo\foo\foo\foo.pdb");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(source.FullName)
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                        ["FileMatch"] = "foo.pdb"
+                    }
+                },
+                Sleep = duration => { }
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+
+            destination.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    "foo.pdb",
+                    @"foo\foo\foo\foo.pdb"
+                }.Select(i => Path.Combine(destination.FullName, i)));
+        }
+    }
+}

--- a/src/Artifacts/ExtensionMethods.cs
+++ b/src/Artifacts/ExtensionMethods.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Framework;
+using System;
+
+namespace Microsoft.Build.Artifacts
+{
+    internal static class ExtensionMethods
+    {
+        public static bool GetMetadataBoolean(this ITaskItem item, string metadataName, bool defaultValue = true)
+        {
+            string value = item.GetMetadata(metadataName);
+
+            if (defaultValue)
+            {
+                return !String.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
+            }
+
+            return String.Equals(value, "true", StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Artifacts/FileSystem.cs
+++ b/src/Artifacts/FileSystem.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.Artifacts
+{
+    internal sealed class FileSystem : IFileSystem
+    {
+        private FileSystem()
+        {
+        }
+
+        public static FileSystem Instance { get; } = new FileSystem();
+
+        public FileInfo CopyFile(FileInfo source, string destFileName, bool overwrite)
+        {
+            return source.CopyTo(destFileName, overwrite);
+        }
+
+        public DirectoryInfo CreateDirectory(string path)
+        {
+            return Directory.CreateDirectory(path);
+        }
+
+        public bool DirectoryExists(string path)
+        {
+            return Directory.Exists(path);
+        }
+
+        public IEnumerable<DirectoryInfo> EnumerateDirectories(DirectoryInfo path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            return path.EnumerateDirectories(searchPattern, searchOption);
+        }
+
+        public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateDirectories(path, searchPattern, searchOption);
+        }
+
+        public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
+        {
+            return Directory.EnumerateFiles(path, searchPattern, searchOption);
+        }
+
+        public IEnumerable<FileInfo> EnumerateFiles(DirectoryInfo path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
+        {
+            return path.EnumerateFiles(searchPattern, searchOption);
+        }
+
+        public bool FileExists(string path)
+        {
+            return File.Exists(path);
+        }
+
+        public bool FileExists(FileInfo file)
+        {
+            return file.Exists;
+        }
+    }
+}

--- a/src/Artifacts/IFileSystem.cs
+++ b/src/Artifacts/IFileSystem.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System.Collections.Generic;
+using System.IO;
+
+namespace Microsoft.Build.Artifacts
+{
+    internal interface IFileSystem
+    {
+        FileInfo CopyFile(FileInfo source, string destination, bool overwrite);
+
+        DirectoryInfo CreateDirectory(string path);
+
+        bool DirectoryExists(string path);
+
+        IEnumerable<string> EnumerateDirectories(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        IEnumerable<DirectoryInfo> EnumerateDirectories(DirectoryInfo path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        IEnumerable<string> EnumerateFiles(string path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        IEnumerable<FileInfo> EnumerateFiles(DirectoryInfo path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly);
+
+        bool FileExists(string path);
+
+        bool FileExists(FileInfo file);
+    }
+}

--- a/src/Artifacts/Microsoft.Build.Artifacts.csproj
+++ b/src/Artifacts/Microsoft.Build.Artifacts.csproj
@@ -1,0 +1,21 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net46;netcoreapp2.1</TargetFrameworks>
+    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
+    <EnableDefaultNoneItems>true</EnableDefaultNoneItems>
+    <PackageLicenseFile></PackageLicenseFile>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="build\*" Pack="true" PackagePath="build\" />
+    <None Include="buildCrossTargeting\*" Pack="true" PackagePath="buildCrossTargeting\" />
+    <None Include="Sdk\*" Pack="true" PackagePath="Sdk\" />
+  </ItemGroup>
+
+</Project>

--- a/src/Artifacts/Properties/AssemblyInfo.cs
+++ b/src/Artifacts/Properties/AssemblyInfo.cs
@@ -1,0 +1,7 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Microsoft.Build.Artifacts.UnitTests")]

--- a/src/Artifacts/Sdk/Sdk.props
+++ b/src/Artifacts/Sdk/Sdk.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="..\build\Microsoft.Build.Artifacts.props" />
+</Project>

--- a/src/Artifacts/Sdk/Sdk.targets
+++ b/src/Artifacts/Sdk/Sdk.targets
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="..\build\Microsoft.Build.Artifacts.targets" />
+</Project>

--- a/src/Artifacts/Tasks/Robocopy.cs
+++ b/src/Artifacts/Tasks/Robocopy.cs
@@ -1,0 +1,293 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+
+namespace Microsoft.Build.Artifacts.Tasks
+{
+    public class Robocopy : Task
+    {
+        private TimeSpan _retryWaitInMilliseconds = TimeSpan.Zero;
+
+        public int RetryCount { get; set; }
+
+        public int RetryWait { get; set; }
+
+        public bool ShowDiagnosticTrace { get; set; }
+
+        public bool ShowErrorOnRetry { get; set; }
+
+        [Required]
+        public ITaskItem[] Sources { get; set; }
+
+        internal IFileSystem FileSystem { get; set; } = Artifacts.FileSystem.Instance;
+
+        internal Action<TimeSpan> Sleep { get; set; } = Thread.Sleep;
+
+        public override bool Execute()
+        {
+            RetryCount = Math.Max(0, RetryCount);
+            _retryWaitInMilliseconds = RetryWait < 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(RetryWait);
+
+            int count = 0;
+            foreach (IList<RobocopyMetadata> bucket in GetBuckets())
+            {
+                CopyItems(bucket);
+                count++;
+            }
+
+            Log.LogMessage("Processed {0} bucket(s)", count);
+            return !Log.HasLoggedErrors;
+        }
+
+        private void CopyFile(FileInfo sourceFile, FileInfo destFile, bool createDirs, RobocopyMetadata metadata)
+        {
+            if (createDirs)
+            {
+                CreateDirectoryWithRetries(destFile.DirectoryName);
+            }
+
+            for (int retry = 0; retry <= RetryCount; ++retry)
+            {
+                try
+                {
+                    if (metadata.ShouldCopy(FileSystem, sourceFile, destFile))
+                    {
+                        destFile = FileSystem.CopyFile(sourceFile, destFile.FullName, true);
+                        destFile.Attributes = FileAttributes.Normal;
+                        destFile.LastWriteTime = sourceFile.LastWriteTime;
+                        Log.LogMessage(MessageImportance.Low, "Copied {0} to {1}", sourceFile.FullName, destFile.FullName);
+                    }
+                    else
+                    {
+                        Log.LogMessage(MessageImportance.Low, "Skipped copying {0} to {1}", sourceFile.FullName, destFile.FullName);
+                    }
+
+                    break;
+                }
+                catch (IOException e)
+                {
+                    LogCopyFailureAndSleep(retry, "Failed to copy {0} to {1}. {2}", sourceFile.FullName, destFile.FullName, e.Message);
+                }
+            }
+        }
+
+        private void CopyItems(IList<RobocopyMetadata> items)
+        {
+            // buckets are grouped by source, IsRecursive, and HasWildcardMatches
+            RobocopyMetadata master = items[0];
+            bool isRecursive = master.IsRecursive;
+            bool hasWildcards = master.HasWildcardMatches;
+            DirectoryInfo source = new DirectoryInfo(master.SourceFolder);
+
+            if (hasWildcards || isRecursive)
+            {
+                string match = GetMatchString(items);
+                CopySearch(items, isRecursive, match, source, null);
+            }
+            else
+            {
+                // optimized path for direct file copies
+                CopyItems(items, source);
+            }
+        }
+
+        private void CopyItems(IList<RobocopyMetadata> items, DirectoryInfo source)
+        {
+            foreach (RobocopyMetadata item in items)
+            {
+                bool createDirs = true;
+                foreach (string file in item.FileMatches)
+                {
+                    FileInfo sourceFile = new FileInfo(Path.Combine(source.FullName, file));
+                    if (Verify(sourceFile, true, item.VerifyExists))
+                    {
+                        foreach (string destination in item.DestinationFolders)
+                        {
+                            FileInfo destFile = new FileInfo(Path.Combine(destination, file));
+                            if (Verify(destFile, false, false))
+                            {
+                                CopyFile(sourceFile, destFile, createDirs, item);
+                            }
+                        }
+
+                        // only try to create the dirs for the first set of files
+                        createDirs = false;
+                    }
+                }
+            }
+        }
+
+        private void CopySearch(IList<RobocopyMetadata> bucket, bool isRecursive, string match, DirectoryInfo source, string subDirectory)
+        {
+            bool hasSubDirectory = !string.IsNullOrEmpty(subDirectory);
+            foreach (FileInfo sourceFile in FileSystem.EnumerateFiles(source, match))
+            {
+                foreach (RobocopyMetadata item in bucket)
+                {
+                    if (item.IsMatch(sourceFile.Name, subDirectory, isFile: true))
+                    {
+                        foreach (string destination in item.DestinationFolders)
+                        {
+                            string fullDest = hasSubDirectory ? Path.Combine(destination, subDirectory) : destination;
+                            FileInfo destFile = new FileInfo(Path.Combine(fullDest, sourceFile.Name));
+
+                            Verify(destFile, false, false);
+                            CopyFile(sourceFile, destFile, true, item);
+                        }
+                    }
+                }
+            }
+
+            // Doing recursion manually so we can consider DirExcludes
+            if (isRecursive)
+            {
+                foreach (DirectoryInfo childSource in FileSystem.EnumerateDirectories(source))
+                {
+                    // per dir we need to re-items for those items excluding a specific dir
+                    string childSubDirectory = hasSubDirectory ? Path.Combine(subDirectory, childSource.Name) : childSource.Name;
+                    IList<RobocopyMetadata> subBucket = new List<RobocopyMetadata>();
+                    foreach (RobocopyMetadata item in bucket)
+                    {
+                        if (item.IsMatch(childSubDirectory, subDirectory, isFile: false))
+                        {
+                            subBucket.Add(item);
+                        }
+                    }
+
+                    CopySearch(subBucket, isRecursive: true, match, childSource, childSubDirectory);
+                }
+            }
+        }
+
+        private void CreateDirectoryWithRetries(string directory)
+        {
+            // Doing 4 tries with a tiny wait just to catch races
+            for (int i = 0; i < 4; ++i)
+            {
+                try
+                {
+                    FileSystem.CreateDirectory(directory);
+
+                    break;
+                }
+                catch (IOException)
+                {
+                    /* ignore failures - we'll catch them later on copy */
+                    Sleep(TimeSpan.FromMilliseconds(200));
+                }
+            }
+        }
+
+        private IEnumerable<IList<RobocopyMetadata>> GetBuckets()
+        {
+            IList<RobocopyMetadata> allSources = new List<RobocopyMetadata>();
+            IList<IList<RobocopyMetadata>> allBuckets = new List<IList<RobocopyMetadata>>();
+
+            foreach (ITaskItem item in Sources ?? Enumerable.Empty<ITaskItem>())
+            {
+                if (RobocopyMetadata.TryParse(item, Log, FileSystem.DirectoryExists, out RobocopyMetadata metadata))
+                {
+                    allSources.Add(metadata);
+                }
+            }
+
+            int bucketNum = -1;
+            int itemIndex = 0;
+            while (allSources.Count > 0)
+            {
+                RobocopyMetadata masterItem = allSources[0];
+                allSources.RemoveAt(0);
+
+                List<RobocopyMetadata> bucket = new List<RobocopyMetadata>
+                {
+                    masterItem
+                };
+
+                allBuckets.Add(bucket);
+
+                if (ShowDiagnosticTrace)
+                {
+                    masterItem.Dump(Log, ++bucketNum, 0);
+                    itemIndex = 1;
+                }
+
+                for (int i = 0; i < allSources.Count; ++i)
+                {
+                    RobocopyMetadata item = allSources[i];
+                    if (string.Equals(item.SourceFolder, masterItem.SourceFolder, StringComparison.OrdinalIgnoreCase) &&
+                        item.HasWildcardMatches == masterItem.HasWildcardMatches &&
+                        item.IsRecursive == masterItem.IsRecursive)
+                    {
+                        bucket.Add(item);
+                        allSources.RemoveAt(i);
+                        --i;
+
+                        if (ShowDiagnosticTrace)
+                        {
+                            item.Dump(Log, bucketNum, itemIndex++);
+                        }
+                    }
+                }
+            }
+
+            return allBuckets;
+        }
+
+        private string GetMatchString(IList<RobocopyMetadata> bucket)
+        {
+            string match = "*";
+            if (bucket.Count == 1)
+            {
+                bucket[0].GetMatchString();
+            }
+
+            return match;
+        }
+
+        private void LogCopyFailureAndSleep(int attempt, string message, params object[] args)
+        {
+            if (attempt > 0)
+            {
+                message += $" :  retry {attempt}/{RetryCount}";
+            }
+
+            if (ShowErrorOnRetry)
+            {
+                Log.LogError(message, args);
+            }
+            else
+            {
+                Log.LogMessage(message, args);
+            }
+
+            if (attempt < RetryCount && RetryWait > 0)
+            {
+                Log.LogMessage("attempt in {0}ms", RetryWait);
+                Sleep(_retryWaitInMilliseconds);
+            }
+        }
+
+        private bool Verify(FileInfo file, bool shouldExist, bool verifyExists)
+        {
+            if (!shouldExist || FileSystem.FileExists(file))
+            {
+                return true;
+            }
+
+            if (verifyExists)
+            {
+                Log.LogError("Copy failed - file does not exist [{0}]", file.FullName);
+            }
+
+            return false;
+        }
+    }
+}

--- a/src/Artifacts/Tasks/RobocopyMetadata.cs
+++ b/src/Artifacts/Tasks/RobocopyMetadata.cs
@@ -1,0 +1,360 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Artifacts.Tasks
+{
+    internal sealed class RobocopyMetadata
+    {
+        private static readonly char[] DestinationSplitter = { ';' };
+        private static readonly char[] MultiSplits = { '\t', ' ', '\n', '\r' };
+        private static readonly char[] Wildcards = { '?', '*' };
+
+        private RobocopyMetadata()
+        {
+        }
+
+        public bool AlwaysCopy { get; private set; }
+
+        public List<string> DestinationFolders { get; } = new List<string>();
+
+        public string[] DirExcludes { get; private set; }
+
+        public Regex[] DirRegexExcludes { get; private set; }
+
+        public bool DoMatchAll { get; private set; }
+
+        public string[] FileExcludes { get; private set; }
+
+        public string[] FileMatches { get; private set; }
+
+        public Regex[] FileRegexExcludes { get; private set; }
+
+        public Regex[] FileRegexMatches { get; private set; }
+
+        public int FilesFound { get; private set; }
+
+        public int FilesFoundRecursive { get; private set; }
+
+        public int FilesSearched { get; private set; }
+
+        public int FilesSearchedRecursive { get; private set; }
+
+        public string[] FileWildcardMatches { get; private set; }
+
+        public bool HasWildcardMatches { get; private set; }
+
+        public bool IsRecursive { get; private set; }
+
+        public string SourceFolder { get; private set; }
+
+        public bool VerifyExists { get; private set; }
+
+        private bool OnlyNewer { get; set; }
+
+        public static bool TryParse(ITaskItem item, TaskLoggingHelper log, Func<string, bool> directoryExists, out RobocopyMetadata metadata)
+        {
+            metadata = null;
+
+            if (string.IsNullOrEmpty(item.GetMetadata("DestinationFolder")))
+            {
+                log.LogError("A value for \"DestinationFolder\" is required for the item \"{0}\".", item.ItemSpec);
+                return false;
+            }
+
+            // A common error - a property doesn't resolve and it references the drive root
+            if (item.ItemSpec.StartsWith(@"\") && !item.ItemSpec.StartsWith(@"\\"))
+            {
+                log.LogError("The specified source location \"{0}\" cannot start with '\'", item.ItemSpec);
+                return false;
+            }
+
+            string source;
+            try
+            {
+                source = Path.GetFullPath(item.ItemSpec).TrimEnd(Path.DirectorySeparatorChar);
+            }
+            catch (Exception e)
+            {
+                log.LogError("Failed to expand the path \"{0}\".", item.ItemSpec);
+                log.LogErrorFromException(e);
+
+                return false;
+            }
+
+            metadata = new RobocopyMetadata
+            {
+                IsRecursive = item.GetMetadataBoolean(nameof(IsRecursive)),
+                VerifyExists = item.GetMetadataBoolean(nameof(VerifyExists)),
+                AlwaysCopy = item.GetMetadataBoolean(nameof(AlwaysCopy), defaultValue: false),
+                OnlyNewer = item.GetMetadataBoolean(nameof(OnlyNewer), defaultValue: false),
+            };
+
+            foreach (string destination in item.GetMetadata("DestinationFolder").Split(DestinationSplitter, StringSplitOptions.RemoveEmptyEntries))
+            {
+                if (destination.StartsWith(@"\") && !destination.StartsWith(@"\\"))
+                {
+                    log.LogError("The specified destination \"{0}\" cannot start with '{1}'", destination, Path.DirectorySeparatorChar);
+                    return false;
+                }
+
+                try
+                {
+                    metadata.DestinationFolders.Add(Path.GetFullPath(destination).TrimEnd(Path.DirectorySeparatorChar));
+                }
+                catch (Exception e)
+                {
+                    log.LogError("Failed to expand the path \"{0}\".", item.ItemSpec);
+                    log.LogErrorFromException(e);
+
+                    return false;
+                }
+            }
+
+            if (directoryExists(source))
+            {
+                metadata.SourceFolder = source;
+                metadata.SplitItems("FileMatch", item);
+                metadata.SplitItems("FileExclude", item);
+                metadata.SplitItems("DirExclude", item);
+                metadata.HasWildcardMatches = metadata.FileRegexMatches != null || metadata.FileRegexExcludes != null || metadata.DirRegexExcludes != null;
+            }
+            else
+            {
+                metadata.IsRecursive = false;
+                metadata.SourceFolder = Path.GetDirectoryName(source);
+                metadata.FileMatches = new[] { Path.GetFileName(source) };
+
+                if (metadata.SourceFolder == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        public void Dump(TaskLoggingHelper log, int bucketId, int bucketIndex)
+        {
+            log.LogMessage(
+                "[{0},{1}] - src[{2}] dest[{3}] match[{4}] fEx[{5}] dEx[{6}] vfy[{7}] rcsv[{8}]",
+                bucketId,
+                bucketIndex,
+                SourceFolder,
+                string.Join(";", DestinationFolders),
+                DumpString(FileMatches, FileRegexMatches),
+                DumpString(FileExcludes, FileRegexExcludes),
+                DumpString(DirExcludes, DirRegexExcludes),
+                VerifyExists,
+                IsRecursive);
+        }
+
+        public string GetMatchString()
+        {
+            return FileMatches.Length + FileWildcardMatches.Length == 1
+                ? FileMatches.Length == 1 ? FileMatches[0] : FileWildcardMatches[0]
+                : "*";
+        }
+
+        public bool IsMatch(string item, string subDirectory, bool isFile)
+        {
+            bool isMatch = false;
+            bool isDeep = !string.IsNullOrEmpty(subDirectory);
+            string deepDir = isDeep ? Path.Combine(SourceFolder, subDirectory) : SourceFolder;
+            string deepItem = isDeep ? Path.Combine(subDirectory, item) : item;
+            string rootedItem = Path.Combine(deepDir, item);
+
+            if (isFile)
+            {
+                ++FilesSearched;
+                if (isDeep)
+                {
+                    ++FilesSearchedRecursive;
+                }
+
+                if (DoMatchAll || FileMatches.Length == 0 && FileRegexMatches.Length == 0)
+                {
+                    isMatch = true;
+                }
+                else
+                {
+                    foreach (string match in FileMatches)
+                    {
+                        bool isRooted = Path.IsPathRooted(match);
+                        if (isRooted && string.Equals(match, rootedItem, StringComparison.OrdinalIgnoreCase) ||
+                           !isRooted && string.Equals(match, item, StringComparison.OrdinalIgnoreCase))
+                        {
+                            isMatch = true;
+                            break;
+                        }
+                    }
+
+                    if (!isMatch)
+                    {
+                        foreach (Regex match in FileRegexMatches)
+                        {
+                            // Allow for wildcard directories but not rooted ones
+                            if (match.IsMatch(item) || isDeep && match.IsMatch(deepItem))
+                            {
+                                isMatch = true;
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                foreach (string exclude in FileExcludes)
+                {
+                    bool isRooted = Path.IsPathRooted(exclude);
+                    if (isRooted && rootedItem.Equals(exclude, StringComparison.OrdinalIgnoreCase) ||
+                       !isRooted && item.Equals(exclude, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+                }
+
+                foreach (Regex exclude in FileRegexExcludes)
+                {
+                    // Allow for wildcard directories but not rooted ones
+                    if (exclude.IsMatch(item) || isDeep && exclude.IsMatch(deepItem))
+                    {
+                        return false;
+                    }
+                }
+
+                ++FilesFound;
+                if (isDeep)
+                {
+                    ++FilesFoundRecursive;
+                }
+            }
+            else
+            {
+                isMatch = true;
+                foreach (string exclude in DirExcludes)
+                {
+                    // Exclude directories with matching sub-directory
+                    if (rootedItem.EndsWith(exclude, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return false;
+                    }
+                }
+
+                foreach (Regex exclude in DirRegexExcludes)
+                {
+                    // Allow for wildcard directories but not rooted ones
+                    if (exclude.IsMatch(item) || isDeep && exclude.IsMatch(deepItem))
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return isMatch;
+        }
+
+        public bool ShouldCopy(IFileSystem fileSystem, FileInfo source, FileInfo dest)
+        {
+            if (AlwaysCopy || !fileSystem.FileExists(dest))
+            {
+                return true;
+            }
+
+            DateTime sourceWrite = source.LastWriteTime;
+            DateTime destWrite = dest.LastWriteTime;
+
+            bool shouldCopy = OnlyNewer && sourceWrite > destWrite || !OnlyNewer && sourceWrite != destWrite;
+
+            return shouldCopy;
+        }
+
+        private string DumpString(string[] noWild, Regex[] wild)
+        {
+            StringBuilder builder = new StringBuilder();
+            if (noWild != null)
+            {
+                foreach (string item in noWild)
+                {
+                    if (builder.Length != 0)
+                    {
+                        builder.Append(";");
+                    }
+
+                    builder.Append(item);
+                }
+            }
+
+            if (wild != null)
+            {
+                foreach (Regex item in wild)
+                {
+                    if (builder.Length != 0)
+                    {
+                        builder.Append(";");
+                    }
+
+                    builder.Append(item);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        private void SplitItems(string metadata, ITaskItem taskItem)
+        {
+            string items = taskItem.GetMetadata(metadata);
+            List<string> strings = new List<string>();
+            List<string> preRegex = new List<string>();
+            List<Regex> regularExpressions = new List<Regex>();
+            bool doMatchAll = false;
+            if (!string.IsNullOrEmpty(items))
+            {
+                foreach (string item in items.Split(MultiSplits, StringSplitOptions.RemoveEmptyEntries))
+                {
+                    if (item == "*")
+                    {
+                        doMatchAll = true;
+                    }
+                    else if (item.IndexOfAny(Wildcards) >= 0)
+                    {
+                        preRegex.Add(item);
+                        string regexString = item.Replace(@"\", @"\\").Replace(".", "[.]").Replace("?", ".").Replace("*", ".*");
+                        regularExpressions.Add(new Regex($"^{regexString}$", RegexOptions.IgnoreCase));
+                    }
+                    else
+                    {
+                        strings.Add(item);
+                    }
+                }
+            }
+
+            switch (metadata)
+            {
+                case "FileMatch":
+                    DoMatchAll = doMatchAll;
+                    FileMatches = strings.ToArray();
+                    FileRegexMatches = regularExpressions.ToArray();
+                    FileWildcardMatches = preRegex.ToArray();
+                    break;
+
+                case "FileExclude":
+                    FileExcludes = strings.ToArray();
+                    FileRegexExcludes = regularExpressions.ToArray();
+                    break;
+
+                case "DirExclude":
+                    DirExcludes = strings.ToArray();
+                    DirRegexExcludes = regularExpressions.ToArray();
+                    break;
+            }
+        }
+    }
+}

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.props
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.props
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CustomBeforeArtifactsProps)"
+          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomBeforeArtifactsProps)' != '' And Exists('$(CustomBeforeArtifactsProps)') " />
+
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  
+  <Import Project="$(CustomAfterArtifactsProps)"
+          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomAfterArtifactsProps)' != '' And Exists('$(CustomAfterArtifactsProps)') " />
+</Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.targets
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CustomBeforeArtifactsTargets)"
+          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomBeforeArtifactsTargets)' != '' And Exists('$(CustomBeforeArtifactsTargets)') " />
+
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Robocopy"
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net46\Microsoft.Build.Artifacts.dll'))"
+             Condition="'$(MSBuildRuntimeType)' != 'Core'" />
+  <UsingTask TaskName="Robocopy"
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netcoreapp2.1\Microsoft.Build.Artifacts.dll'))"
+             Condition="'$(MSBuildRuntimeType)' == 'Core'" />
+
+  <ItemDefinitionGroup>
+    <Robocopy>
+      <Visible>false</Visible>
+      <VerifyExists>true</VerifyExists>
+    </Robocopy>
+    <Artifacts>
+      <Visible>false</Visible>
+      <VerifyExists>true</VerifyExists>
+    </Artifacts>
+  </ItemDefinitionGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != ''">
+    <!--
+      By default copy the contents of $(DefaultArtifactsSource) (default is $(OutputPath)) to $(ArtifactsPath) unless:
+       * EnableDefaultArtifacts is 'false'
+       * $(ArtifactsPath) is not specified
+    -->
+    <Artifacts Include="$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))"
+               DestinationFolder="$(ArtifactsPath)"
+               FileMatch="$([MSBuild]::ValueOrDefault($(DefaultArtifactsFileMatch), '*exe *dll *exe.config'))" />
+  </ItemGroup>
+
+  <Target Name="CopyArtifacts"
+          AfterTargets="$([MSBuild]::ValueOrDefault($(CopyArtifactsAfterTargets), 'AfterBuild'))"
+          DependsOnTargets="$(CopyArtifactsDependsOn)">
+
+    <Robocopy
+      RetryCount="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryCount), $(CopyRetryCount)))"
+      RetryWait="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryDelayMilliseconds), $(CopyRetryDelayMilliseconds)))"
+      ShowDiagnosticTrace="$(ArtifactsShowDiagnostics)"
+      ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(ArtifactsShowErrorOnRetry), 'true'))"
+      Sources="@(Artifacts)"
+      Condition="@(Artifacts->Count()) > 0" />
+
+  </Target>
+
+  <Target Name="RobocopyFiles"
+          AfterTargets="$([MSBuild]::ValueOrDefault($(RobocopyFilesAfterTargets), 'AfterBuild'))"
+          DependsOnTargets="$(RobocopyFilesDependsOn)">
+
+    <Robocopy
+      RetryCount="$([MSBuild]::ValueOrDefault($(RobocopyRetryCount), $(CopyRetryCount)))"
+      RetryWait="$([MSBuild]::ValueOrDefault($(RobocopyRetryWait), $(CopyRetryDelayMilliseconds)))"
+      ShowDiagnosticTrace="$(RobocopyShowDiagnosticTrace)"
+      ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(RobocopyShowErrorOnRetry), 'true'))"
+      Sources="@(Robocopy)"
+      Condition="@(Robocopy->Count()) > 0"/>
+
+  </Target>
+  
+  <Import Project="$(CustomAfterArtifactsTargets)"
+          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomAfterArtifactsTargets)' != '' And Exists('$(CustomAfterArtifactsTargets)') " />
+</Project>

--- a/src/Artifacts/buildCrossTargeting/Microsoft.Build.Artifacts.props
+++ b/src/Artifacts/buildCrossTargeting/Microsoft.Build.Artifacts.props
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="..\build\Microsoft.Build.Artifacts.props" />
+</Project>

--- a/src/Artifacts/buildCrossTargeting/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/buildCrossTargeting/Microsoft.Build.Artifacts.targets
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+  </PropertyGroup>
+  <Import Project="..\build\Microsoft.Build.Artifacts.targets" />
+</Project>

--- a/src/Artifacts/version.json
+++ b/src/Artifacts/version.json
@@ -1,0 +1,4 @@
+﻿{
+  "inherit": true,
+  "version": "1.0-preview"
+}

--- a/src/GlobalSuppressions.cs
+++ b/src/GlobalSuppressions.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1601:EnableXmlDocumentationOutput", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1652:PartialElementsMustBeDocumented", Justification = "Reviewed.")]
+[assembly: SuppressMessage("StyleCop.CSharp.MaintainabilityRules", "SA1408:ConditionalExpressionsMustDeclarePrecedence", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.NamingRules", "SA1309:FieldNamesMustNotBeginWithUnderscore", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:PrefixLocalCallsWithThis", Justification = "Reviewed.")]
 [assembly: SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines", Justification = "Reviewed.")]

--- a/src/UnitTest.Common/MSBuildSdkTestBase.cs
+++ b/src/UnitTest.Common/MSBuildSdkTestBase.cs
@@ -5,6 +5,7 @@
 using Microsoft.Build.Utilities.ProjectCreation;
 using System;
 using System.IO;
+using System.Linq;
 
 namespace UnitTest.Common
 {
@@ -25,6 +26,20 @@ namespace UnitTest.Common
         {
             Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        protected DirectoryInfo CreateFiles(string directoryName, params string[] files)
+        {
+            DirectoryInfo directory = new DirectoryInfo(Path.Combine(TestRootPath, directoryName));
+
+            foreach (FileInfo file in files.Select(i => new FileInfo(Path.Combine(directory.FullName, i))))
+            {
+                file.Directory.Create();
+
+                File.WriteAllBytes(file.FullName, new byte[0]);
+            }
+
+            return directory;
         }
 
         protected virtual void Dispose(bool disposing)

--- a/src/UnitTest.Common/MockTaskItem.cs
+++ b/src/UnitTest.Common/MockTaskItem.cs
@@ -1,0 +1,76 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Framework;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace UnitTest.Common
+{
+    public class MockTaskItem : Dictionary<string, string>, ITaskItem2
+    {
+        public MockTaskItem(string itemSpec)
+            : base(StringComparer.OrdinalIgnoreCase)
+        {
+            ItemSpec = itemSpec;
+        }
+
+        public string EvaluatedIncludeEscaped { get; set; }
+
+        public string ItemSpec { get; set; }
+
+        public int MetadataCount => Count;
+
+        public ICollection MetadataNames => Keys;
+
+        public IDictionary CloneCustomMetadata()
+        {
+            return new Dictionary<string, string>(this, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public IDictionary CloneCustomMetadataEscaped()
+        {
+            return CloneCustomMetadata();
+        }
+
+        public void CopyMetadataTo(ITaskItem destinationItem)
+        {
+            foreach (KeyValuePair<string, string> pair in this)
+            {
+                destinationItem.SetMetadata(pair.Key, pair.Value);
+            }
+        }
+
+        public string GetMetadata(string metadataName)
+        {
+            if (TryGetValue(metadataName, out string value))
+            {
+                return value;
+            }
+
+            return String.Empty;
+        }
+
+        public string GetMetadataValueEscaped(string metadataName)
+        {
+            return GetMetadata(metadataName);
+        }
+
+        public void RemoveMetadata(string metadataName)
+        {
+            Remove(metadataName);
+        }
+
+        public void SetMetadata(string metadataName, string metadataValue)
+        {
+            this[metadataName] = metadataValue;
+        }
+
+        public void SetMetadataValueLiteral(string metadataName, string metadataValue)
+        {
+            SetMetadata(metadataName, metadataValue);
+        }
+    }
+}


### PR DESCRIPTION
This package will let users stage their artifacts for hosted build environments like Azure DevOps.

If a project sets the $(ArtifactsPath) property, the contents of its $(OutputPath) are copied.  Otherwise, you can add @(Artifacts) items that specify a source, destination, and filter.