### PR TITLE
Disable CentralPackageVersions for .nuproj projects

### DIFF
--- a/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
+++ b/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
@@ -111,6 +111,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
         [InlineData(true, ".sfproj")]
         [InlineData(false, ".ccproj")]
         [InlineData(false, ".vcxproj")]
+        [InlineData(false, ".nuproj")]
         public void IsDisabledForProjectsWithPackagesConfigOrDoNotSupportPackageReference(bool createPackagesConfig, string extension)
         {
             WritePackagesProps();

--- a/src/CentralPackageVersions/Sdk/Sdk.targets
+++ b/src/CentralPackageVersions/Sdk/Sdk.targets
@@ -23,10 +23,10 @@
       * The central package management file does not exist.
       * The project is using packages.config.  Visual Studio project systems will get confused if there are any PackageReference
         items and it won't show the packages in the packages.config.  NuGet does not support using both and so packages.config has to win.
-      * The project is a type that doesn't not support PackageReference in Visual Studio (like vcxproj or ccproj).
+      * The project is a type that doesn't not support PackageReference in Visual Studio (like vcxproj, ccproj, or nuproj).
     -->
     <EnableCentralPackageVersions
-      Condition="!Exists('$(CentralPackagesFile)') Or Exists('$(MSBuildProjectDirectory)\packages.config') Or '$(MSBuildProjectExtension)' == '.vcxproj' Or '$(MSBuildProjectExtension)' == '.ccproj'">false</EnableCentralPackageVersions>
+      Condition="!Exists('$(CentralPackagesFile)') Or Exists('$(MSBuildProjectDirectory)\packages.config') Or '$(MSBuildProjectExtension)' == '.vcxproj' Or '$(MSBuildProjectExtension)' == '.ccproj' Or '$(MSBuildProjectExtension)' == '.nuproj'">false</EnableCentralPackageVersions>
 
     <!--
       Include this file and the Packages.props file (if necessary) in MSBuildAllProjects so that rebuilds happen if the Packages.props changes.


### PR DESCRIPTION
These projects don't support PackageReference