### PR TITLE
Deprecate some Traversal features

### DIFF
--- a/src/Traversal/README.md
+++ b/src/Traversal/README.md
@@ -67,57 +67,19 @@ Add to the list of custom files to import after Traversal targets.  This can be 
 
 <br />
 
-The following `<ItemGroup />` items extend how Traversal works.
-
-| Item Name                                        | Description |
-|--------------------------------------------------|-------------|
-| `PreTraversalProject`        | A list of projects to build before all other projects.|
-| `PostTraversalProject`       | A list of projects to build after all other projects. |
-| `PreTraversalBuildProject`  | A list of projects to build before all other projects. These projects are built only before the **Build** target.|
-| `PostTraversalBuildProject` | A list of projects to build after all other projects. These projects are built only after the **Build** target.|
-| `PreTraversalCleanProject`  | A list of projects to build before all other projects. These projects are built only before the **Clean** target.|
-| `PostTraversalCleanProject` | A list of projects to build after all other projects. These projects are built only after the **Clean** target.|
-| `PreTraversalTestProject`   | A list of projects to build before all other projects. These projects are built only before the **Test** target.|
-| `PostTraversalTestProject`  | A list of projects to build after all other projects. These projects are built only after the **Test** target.|
-
-**Example**
-
-Have a project named `PreTraversal.proj` built before all other projects.
-```xml
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
-    <PreTraversalProject Include="$(MSBuildThisFileDirectory)PreTraversal.proj"/>
-  </ItemGroup>
-</Project>
-```
-
-<br />
-
 The following properties control global properties passed to different parts of the traversal build.
 
 | Property                            | Description |
 |-------------------------------------|-------------|
-| `PreTraversalGlobalProperties `       | A list of properties to set when building **all** **pre-traversal** projects. |
 | `TraversalGlobalProperties `          | A list of properties to set when building **all** traversal projects. |
-| `PostTraversalGlobalProperties `      | A list of properties to set when building **all** **post-traversal** projects. |
-| `PreTraversalBuildGlobalProperties`  | A list of properties to set when building **pre-traversal** projects. These are only set when building the **Build** target.|
-| `TraversalBuildGlobalProperties`      | A list of properties to set when building traversal projects. These are only set when building the **Build** target.|
-| `PostTraversalBuildGlobalProperties` | A list of properties to set when building **post-traversal** projects. These are only set when building the **Build** target.|
-| `PreTraversalCleanGlobalProperties`  | A list of properties to set when building **pre-traversal** projects. These are only set when building the **Clean** target.|
-| `TraversalCleanGlobalProperties`      | A list of properties to set when building traversal projects. These are only set when building the **Clean** target.|
-| `PostTraversalCleanGlobalProperties` | A list of properties to set when building **post-traversal** projects. These are only set when building the **Clean** target.|
-| `PreTraversalTestGlobalProperties`   | A list of properties to set when building **pre-traversal** projects. These are only set when building the **Test** target.|
-| `TraversalTestGlobalProperties`       | A list of properties to set when building traversal projects. These are only set when building the **Test** target.|
-| `PostTraversalTestGlobalProperties`  | A list of properties to set when building **pre-traversal** projects. These are only set when building the **Test** target.|
 
 **Example**
 
-Set some properties during pre-traversal and post-traversal build.
+Set some properties during build.
 ```xml
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <PreTraversalBuildGlobalProperties>IsPreTraversal=true;EnableSomething=true</PreTraversalBuildGlobalProperties>
-    <PostTraversalBuildGlobalProperties>SomeProperty=Value</PostTraversalBuildGlobalProperties>
+    <TraversalGlobalProperties>Property1=true;EnableSomething=true</TraversalGlobalProperties>
   </PropertyGroup>
 </Project>
 ```

--- a/src/Traversal/Sdk/Sdk.props
+++ b/src/Traversal/Sdk/Sdk.props
@@ -22,7 +22,6 @@
     -->
     <TraversalProjectNames Condition=" '$(TraversalProjectNames)' == '' ">dirs.proj</TraversalProjectNames>
 
-    <IsTraversal Condition=" '$(IsTraversal)' != '' ">$([System.Convert]::ToBoolean($(IsTraversal)))</IsTraversal>
     <IsTraversal Condition=" '$(IsTraversal)' == '' And $(TraversalProjectNames.IndexOf($(MSBuildProjectFile), System.StringComparison.OrdinalIgnoreCase)) >= 0 ">true</IsTraversal>
   </PropertyGroup>
 

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -37,9 +37,6 @@
 
     <ResolveReferencesDependsOn>
       BeforeResolveReferences;
-      AssignProjectConfiguration;
-      ResolveProjectReferences;
-      FindInvalidProjectReferences;
       AfterResolveReferences
     </ResolveReferencesDependsOn>
 
@@ -78,6 +75,11 @@
     <ProjectFile Remove="@(ProjectFile)" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Update="@(ProjectReference)"
+                      Properties="$(TraversalGlobalProperties)" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TraversalRemoveCurrentProject)' != 'false' ">
     <!--
       Remove the dirs.proj in case the user accidentally included it through a glob like **\*.*proj.  Otherwise
@@ -91,41 +93,7 @@
 
   <Target Name="Build"
           DependsOnTargets="$(BuildDependsOn)">
-
-    <MSBuild Projects="@(PreTraversalProject)"
-             Targets="Build"
-             Properties="$(PreTraversalGlobalProperties)"
-             Condition=" '@(PreTraversalProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PreTraversalBuildProject)"
-             Targets="Build"
-             Properties="$(PreTraversalBuildGlobalProperties)"
-             Condition=" '@(PreTraversalBuildProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-             Properties="$(TraversalGlobalProperties);$(TraversalBuildGlobalProperties)"
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalBuildProject)"
-             Targets="Build"
-             Properties="$(PostTraversalBuildGlobalProperties)"
-             Condition=" '@(PostTraversalBuildProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalProject)"
-             Targets="Build"
-             Properties="$(PostTraversalGlobalProperties)"
-             Condition=" '@(PostTraversalProject)' != '' "
+    <MSBuild Projects="@(ProjectReference)"
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />
@@ -133,42 +101,8 @@
 
   <Target Name="Clean"
           DependsOnTargets="$(CleanDependsOn)">
-
-    <MSBuild Projects="@(PreTraversalProject)"
+    <MSBuild Projects="@(ProjectReference)"
              Targets="Clean"
-             Properties="$(PreTraversalGlobalProperties)"
-             Condition=" '@(PreTraversalProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PreTraversalCleanProject)"
-             Targets="Clean"
-             Properties="$(PreTraversalCleanGlobalProperties)"
-             Condition=" '@(PreTraversalCleanProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-             Targets="Clean"
-             Properties="$(TraversalGlobalProperties);$(TraversalCleanGlobalProperties)"
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalCleanProject)"
-             Targets="Clean"
-             Properties="$(PostTraversalCleanGlobalProperties)"
-             Condition=" '@(PostTraversalCleanProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalProject)"
-             Targets="Clean"
-             Properties="$(PostTraversalGlobalProperties)"
-             Condition=" '@(PostTraversalProject)' != '' "
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />
@@ -176,42 +110,8 @@
 
   <Target Name="Test"
           DependsOnTargets="$(TestDependsOn)">
-
-    <MSBuild Projects="@(PreTraversalProject)"
+    <MSBuild Projects="@(ProjectReference)"
              Targets="Test"
-             Properties="$(PreTraversalGlobalProperties)"
-             Condition=" '@(PreTraversalProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PreTraversalTestProject)"
-             Targets="Test"
-             Properties="$(PreTraversalTestGlobalProperties)"
-             Condition=" '@(PreTraversalTestProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-             Targets="Test"
-             Properties="$(TraversalGlobalProperties);$(TraversalTestGlobalProperties)"
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalTestProject)"
-             Targets="Test"
-             Properties="$(PostTraversalTestGlobalProperties)"
-             Condition=" '@(PostTraversalTestProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalProject)"
-             Targets="Test"
-             Properties="$(PostTraversalGlobalProperties)"
-             Condition=" '@(PostTraversalProject)' != '' "
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />
@@ -219,42 +119,8 @@
 
   <Target Name="VSTest"
           DependsOnTargets="$(VSTestDependsOn)">
-
-    <MSBuild Projects="@(PreTraversalProject)"
+    <MSBuild Projects="@(ProjectReference)"
              Targets="VSTest"
-             Properties="$(PreTraversalGlobalProperties)"
-             Condition=" '@(PreTraversalProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PreTraversalVSTestProject)"
-             Targets="VSTest"
-             Properties="$(PreTraversalVSTestGlobalProperties)"
-             Condition=" '@(PreTraversalVSTestProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-             Targets="VSTest"
-             Properties="$(TraversalGlobalProperties);$(TraversalVSTestGlobalProperties)"
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalVSTestProject)"
-             Targets="VSTest"
-             Properties="$(PostTraversalVSTestGlobalProperties)"
-             Condition=" '@(PostTraversalVSTestProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalProject)"
-             Targets="VSTest"
-             Properties="$(PostTraversalGlobalProperties)"
-             Condition=" '@(PostTraversalProject)' != '' "
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />
@@ -262,42 +128,8 @@
 
   <Target Name="Pack"
           DependsOnTargets="$(PackDependsOn)">
-
-    <MSBuild Projects="@(PreTraversalProject)"
+    <MSBuild Projects="@(ProjectReference)"
              Targets="Pack"
-             Properties="$(PreTraversalGlobalProperties)"
-             Condition=" '@(PreTraversalProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PreTraversalPackProject)"
-             Targets="Pack"
-             Properties="$(PreTraversalPackGlobalProperties)"
-             Condition=" '@(PreTraversalPackProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-             Targets="Pack"
-             Properties="$(TraversalGlobalProperties);$(TraversalPackGlobalProperties)"
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalPackProject)"
-             Targets="Pack"
-             Properties="$(PostTraversalPackGlobalProperties)"
-             Condition=" '@(PostTraversalPackProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalProject)"
-             Targets="Pack"
-             Properties="$(PostTraversalGlobalProperties)"
-             Condition=" '@(PostTraversalProject)' != '' "
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />
@@ -305,42 +137,9 @@
 
   <Target Name="Publish"
           DependsOnTargets="$(PublishDependsOn)">
-
-    <MSBuild Projects="@(PreTraversalProject)"
+    <MSBuild Projects="@(ProjectReference)"
+             Properties="$(TraversalPublishGlobalProperties)"
              Targets="Publish"
-             Properties="$(PreTraversalGlobalProperties)"
-             Condition=" '@(PreTraversalProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PreTraversalPublishProject)"
-             Targets="Publish"
-             Properties="$(PreTraversalPublishGlobalProperties)"
-             Condition=" '@(PreTraversalPublishProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(_MSBuildProjectReferenceExistent)"
-             Targets="Publish"
-             Properties="$(TraversalGlobalProperties);$(TraversalPublishGlobalProperties)"
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalPublishProject)"
-             Targets="Publish"
-             Properties="$(PostTraversalPublishGlobalProperties)"
-             Condition=" '@(PostTraversalPublishProject)' != '' "
-             BuildInParallel="$(BuildInParallel)"
-             SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
-
-    <MSBuild Projects="@(PostTraversalProject)"
-             Targets="Publish"
-             Properties="$(PostTraversalGlobalProperties)"
-             Condition=" '@(PostTraversalProject)' != '' "
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)" />

--- a/src/Traversal/version.json
+++ b/src/Traversal/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "1.0"
+  "version": "2.0"
 }


### PR DESCRIPTION
* Don't call ResolveProjectReferences which builds targets that aren't needed
* Set global properties on the @(ProjectReference) items instead of passing them in the <MSBuild /> task.
* Remove Pre/Post traversal projects.  This functionality makes it really hard to do any static predictions.  There are more declarative ways to run logic before/after targets
* Remove individual global properties for each target

Update documentation
Change version to 2.0 because of the breaking changes
Add unit tests

Fixes #86 