### PR TITLE
Allow CentralPackageVersions to be explicitly enabled

### DIFF
--- a/src/CentralPackageVersions/Sdk/Sdk.targets
+++ b/src/CentralPackageVersions/Sdk/Sdk.targets
@@ -26,7 +26,7 @@
       * The project is a type that doesn't not support PackageReference in Visual Studio (like vcxproj, ccproj, or nuproj).
     -->
     <EnableCentralPackageVersions
-      Condition="!Exists('$(CentralPackagesFile)') Or Exists('$(MSBuildProjectDirectory)\packages.config') Or '$(MSBuildProjectExtension)' == '.vcxproj' Or '$(MSBuildProjectExtension)' == '.ccproj' Or '$(MSBuildProjectExtension)' == '.nuproj'">false</EnableCentralPackageVersions>
+      Condition="'$(EnableCentralPackageVersions)' == '' And (!Exists('$(CentralPackagesFile)') Or Exists('$(MSBuildProjectDirectory)\packages.config') Or '$(MSBuildProjectExtension)' == '.vcxproj' Or '$(MSBuildProjectExtension)' == '.ccproj' Or '$(MSBuildProjectExtension)' == '.nuproj')">false</EnableCentralPackageVersions>
 
     <!--
       Include this file and the Packages.props file (if necessary) in MSBuildAllProjects so that rebuilds happen if the Packages.props changes.


### PR DESCRIPTION
Project types that don't support PackageReference have central package versions disabled by default but there's no way for a user to explicitly enable it again.

Fixes #102 