### PR TITLE
Don't build when VSTestNoBuild = true

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -55,7 +55,7 @@
       Build
     </TestDependsOn>
 
-    <VSTestDependsOn>
+    <VSTestDependsOn Condition="'$(VSTestNoBuild)' != 'true'">
       Build
     </VSTestDependsOn>
 


### PR DESCRIPTION
This ensure that Traversal respects the same condition that [VSTest does](https://github.com/microsoft/vstest/blob/master/src/Microsoft.TestPlatform.Build/Microsoft.TestPlatform.targets#L28).