### PR TITLE
Disable resource compilation in NoTargets.

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -15,6 +15,30 @@ namespace Microsoft.Build.NoTargets.UnitTests
     public class NoTargetsTests : MSBuildSdkTestBase
     {
         [Fact]
+        public void EnableDefaultCompileItemsIsFalse()
+        {
+            ProjectCreator.Templates.NoTargetsProject(
+                    path: GetTempFileWithExtension(".csproj"))
+                .Property("GenerateDependencyFile", "false")
+                .Save()
+                .TryGetPropertyValue("EnableDefaultCompileItems", out string enableDefaultCompileItems);
+
+            enableDefaultCompileItems.ShouldBe("false");
+        }
+
+        [Fact]
+        public void EnableDefaultEmbeddedResourceItemsIsFalse()
+        {
+            ProjectCreator.Templates.NoTargetsProject(
+                    path: GetTempFileWithExtension(".csproj"))
+                .Property("GenerateDependencyFile", "false")
+                .Save()
+                .TryGetPropertyValue("EnableDefaultEmbeddedResourceItems", out string enableDefaultEmbeddedResourceItems);
+
+            enableDefaultEmbeddedResourceItems.ShouldBe("false");
+        }
+
+        [Fact]
         public void SimpleBuild()
         {
             ProjectCreator.Templates.NoTargetsProject(

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -13,6 +13,12 @@
 
   <Import Project="$(CustomBeforeNoTargetsProps)" Condition=" '$(CustomBeforeNoTargetsProps)' != '' And Exists('$(CustomBeforeNoTargetsProps)') " />
 
+  <PropertyGroup>
+    <!-- Disable default Compile and EmbeddedResource items for NoTargets projects -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+  </PropertyGroup>
+
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>
 
   <Import Project="$(CustomAfterNoTargetsProps)" Condition=" '$(CustomAfterNoTargetsProps)' != '' And Exists('$(CustomAfterNoTargetsProps)') " />

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -44,6 +44,12 @@
     </CoreBuildDependsOn>
   </PropertyGroup>
 
+  <!--
+    The CopyFilesToOutputDirectory target is hard coded to depend on ComputeIntermediateSatelliteAssemblies.  NoTargets projects do no generate resource assemblies
+    so the target is replaced with a no-op
+  -->
+  <Target Name="ComputeIntermediateSatelliteAssemblies" />
+
   <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
           Condition="'$(DebuggerFlavor)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />


### PR DESCRIPTION
If there are any `.resx` files in the project directory, NoTargets projects try to compile resource assemblies.  This change disables resource assembly compilation as well as adding `*.resx` as `<EmbeddedResource />` items.

Also disable default compile items.

Fixes #113 