### PR TITLE
Set IncludeBuildOutput to false in NoTargets

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -39,6 +39,17 @@ namespace Microsoft.Build.NoTargets.UnitTests
         }
 
         [Fact]
+        public void IncludeBuildOutputIsFalseByDefault()
+        {
+            ProjectCreator.Templates.NoTargetsProject(
+                    path: GetTempFileWithExtension(".csproj"))
+                .Save()
+                .TryGetPropertyValue("IncludeBuildOutput", out string includeBuildOutput);
+
+            includeBuildOutput.ShouldBe("false");
+        }
+
+        [Fact]
         public void SimpleBuild()
         {
             ProjectCreator.Templates.NoTargetsProject(

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -21,6 +21,11 @@
 
   <Import Project="$(CustomBeforeNoTargets)" Condition="'$(CustomBeforeNoTargets)' != '' and Exists('$(CustomBeforeNoTargets)')" />
 
+  <PropertyGroup>
+    <!-- Don't include build output in a package since NoTargets projects don't emit an assembly. -->
+    <IncludeBuildOutput Condition="'$(IncludeBuildOutput)' == ''">false</IncludeBuildOutput>
+  </PropertyGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
 
   <ItemGroup>


### PR DESCRIPTION
This ensures the Pack task does not attempt to include build output from a NoTargets project since it won't emit an assembly.

Fixes #116 