### PR TITLE
Mark Microsoft.AspNetCore.App and Microsoft.AspNetCore.All as implicitly defined

### DIFF
--- a/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
+++ b/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
@@ -338,6 +338,48 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
             buildOutput.Errors.ShouldBe(new[] { $"The package reference \'Foo\' should not specify a version.  Please specify the version in \'{packagesProps.FullPath}\'." });
         }
 
+        [Fact]
+        public void MicrosoftAspNetCoreAllUpdated()
+        {
+            WritePackagesProps();
+
+            ProjectCreator.Templates
+                .SdkCsproj(
+                    path: Path.Combine(TestRootPath, "test.csproj"),
+                    targetFramework: "netcoreapp2.0",
+                    sdk: "Microsoft.NET.Sdk.Web",
+                    projectCreator: creator => creator
+                        .ItemPackageReference("Microsoft.AspNetCore.All")
+                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                .TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem> items);
+
+            items.Where(i => i.EvaluatedInclude.Equals("Microsoft.AspNetCore.All"))
+                .ShouldHaveSingleItem()
+                .GetMetadataValue("IsImplicitlyDefined")
+                .ShouldBe("true");
+        }
+
+        [Fact]
+        public void MicrosoftAspNetCoreAppUpdated()
+        {
+            WritePackagesProps();
+
+            ProjectCreator.Templates
+                .SdkCsproj(
+                    path: Path.Combine(TestRootPath, "test.csproj"),
+                    targetFramework: "netcoreapp2.0",
+                    sdk: "Microsoft.NET.Sdk.Web",
+                    projectCreator: creator => creator
+                        .ItemPackageReference("Microsoft.AspNetCore.App")
+                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                .TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem> items);
+
+            items.Where(i => i.EvaluatedInclude.Equals("Microsoft.AspNetCore.App"))
+                .ShouldHaveSingleItem()
+                .GetMetadataValue("IsImplicitlyDefined")
+                .ShouldBe("true");
+        }
+
         [Theory]
         [InlineData(".csproj")]
         [InlineData(".fsproj")]

--- a/src/CentralPackageVersions/Sdk/Sdk.targets
+++ b/src/CentralPackageVersions/Sdk/Sdk.targets
@@ -69,6 +69,17 @@
                       IsImplicitlyDefined="true" />
 
     <!--
+      Workaround the issue where Microsoft.AspNet.App and Microsoft.AspNet.All are not marked as implicitly defined
+    -->
+    <PackageReference Update="Microsoft.AspNetCore.App"
+                      Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'"
+                      IsImplicitlyDefined="true" />
+
+    <PackageReference Update="Microsoft.AspNetCore.All"
+                      Condition="'$(UsingMicrosoftNETSdkWeb)' == 'true'"
+                      IsImplicitlyDefined="true" />
+
+    <!--
       Store a list of <PackageReference /> items that specified a Version so that an error can be displayed.
     -->
     <_PackageReferenceWithVersion Include="@(PackageReference->HasMetadata('Version'))" />


### PR DESCRIPTION
Certain versions of the ASP.NET Core SDK do not mark these package references as implicitly defined which causes build errors in CentralPackageVersions.

Fixes #118