### PR TITLE
Disable GetTargetPath so that dependent projects build successfully

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -14,7 +14,7 @@
     <PackageReference Update="Microsoft.Build.Framework" Version="16.0.461" />
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="16.0.461" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.1.0" />
-    <PackageReference Update="MSBuild.ProjectCreation" Version="1.2.11" />
+    <PackageReference Update="MSBuild.ProjectCreation" Version="1.2.15" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.1" />

--- a/src/NoTargets.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/NoTargets.UnitTests/CustomProjectCreatorTemplates.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Build.NoTargets.UnitTests
             this ProjectCreatorTemplates templates,
             Action<ProjectCreator> customAction = null,
             string path = null,
+            string targetFramework = "netstandard2.0",
             string defaultTargets = null,
             string initialTargets = null,
             string sdk = null,
@@ -35,7 +36,7 @@ namespace Microsoft.Build.NoTargets.UnitTests
                     projectCollection,
                     projectFileOptions)
                 .Import(Path.Combine(currentDirectory, "Sdk", "Sdk.props"))
-                .Property("TargetFramework", "netstandard1.0")
+                .Property("TargetFramework", targetFramework)
                 .CustomAction(customAction)
                 .Import(Path.Combine(currentDirectory, "Sdk", "Sdk.targets"));
         }

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -59,6 +59,16 @@
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
           Condition="'$(DebuggerFlavor)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />
 
+  <!--
+    NoTargets projects do not build an assembly so dependent projects shouldn't get a path to the target.  Override the GetTargetPath to do nothing.
+  -->
+  <Target Name="GetTargetPath" />
+
+  <!--
+    The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
+  -->
+  <Target Name="GetTargetPathWithTargetPlatformMoniker" />
+
   <Import Project="$(CustomAfterNoTargets)" Condition="'$(CustomAfterNoTargets)' != '' and Exists('$(CustomAfterNoTargets)')" />
   
 </Project>


### PR DESCRIPTION
When a project depends on NoTargets project, dependency resolution will populate a target path even though a NoTargets project doesn't emit an assembly.  The fix is to override GetTargetPath so that it does nothing.

Fixes #128 