### PR TITLE
Improve multi-targeting functionality for artifacts

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -10,10 +10,10 @@
 
   <ItemGroup>
     <PackageReference Update="MicroBuild.Core" Version="0.3.0" />
-    <PackageReference Update="Microsoft.Build" Version="16.0.461" />
-    <PackageReference Update="Microsoft.Build.Framework" Version="16.0.461" />
-    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="16.0.461" />
-    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.1.0" />
+    <PackageReference Update="Microsoft.Build" Version="16.4.0" />
+    <PackageReference Update="Microsoft.Build.Framework" Version="16.4.0" />
+    <PackageReference Update="Microsoft.Build.Utilities.Core" Version="16.4.0" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Update="MSBuild.ProjectCreation" Version="1.2.15" />
     <PackageReference Update="Shouldly" Version="3.0.2" />
     <PackageReference Update="xunit" Version="2.4.1" />
@@ -21,7 +21,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="2.3.151" Condition=" '$(EnableGitVersioning)' != 'false' " />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.0.50" Condition=" '$(EnableGitVersioning)' != 'false' " />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(EnableStyleCop)' != 'false' ">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
 variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'AnyCPU'
-  DotNetCore3Version: '3.0.100'
+  DotNetCore3Version: '3.1.100'
   SignType: 'Test'
 
 trigger:
@@ -31,7 +31,7 @@ jobs:
     vmImage: windows-latest
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET Core 3.0'
+    displayName: 'Install .NET Core 3.1'
     inputs:
       version: '$(DotNetCore3Version)'
   - task: MSBuild@1

--- a/src/Artifacts/Sdk/Sdk.targets
+++ b/src/Artifacts/Sdk/Sdk.targets
@@ -8,5 +8,6 @@
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  <Import Project="..\build\Microsoft.Build.Artifacts.targets" />
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.Build.Artifacts.targets" />
 </Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.props
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.props
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!--
   Copyright (c) Microsoft Corporation. All rights reserved.
-  
+
   Licensed under the MIT license.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
-  </PropertyGroup>
 
-  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.Build.Artifacts.props" />
+    <UsingMicrosoftArtifactsSdk>true</UsingMicrosoftArtifactsSdk>
+  </PropertyGroup>
 </Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!--
+      Copy artifacts after Pack if GeneratePackageOnBuild is true
+    -->
+    <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == '' And '$(GeneratePackageOnBuild)' == 'true'">Pack</CopyArtifactsAfterTargets>
+  </PropertyGroup>
+
+
+  <UsingTask TaskName="Robocopy"
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net46\Microsoft.Build.Artifacts.dll'))"
+             Condition="'$(MSBuildRuntimeType)' != 'Core'" />
+  <UsingTask TaskName="Robocopy"
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netcoreapp2.1\Microsoft.Build.Artifacts.dll'))"
+             Condition="'$(MSBuildRuntimeType)' == 'Core'" />
+
+  <ItemDefinitionGroup>
+    <Robocopy>
+      <Visible>false</Visible>
+      <VerifyExists>true</VerifyExists>
+    </Robocopy>
+    <Artifact>
+      <Visible>false</Visible>
+      <VerifyExists>true</VerifyExists>
+    </Artifact>
+  </ItemDefinitionGroup>
+
+  <Target Name="CopyArtifacts"
+          Condition="'$(EnableArtifacts)' != 'false'"
+          AfterTargets="$([MSBuild]::ValueOrDefault($(CopyArtifactsAfterTargets), 'AfterBuild'))"
+          DependsOnTargets="$(CopyArtifactsDependsOn)">
+    <Robocopy
+      RetryCount="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryCount), $(CopyRetryCount)))"
+      RetryWait="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryDelayMilliseconds), $(CopyRetryDelayMilliseconds)))"
+      ShowDiagnosticTrace="$(ArtifactsShowDiagnostics)"
+      ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(ArtifactsShowErrorOnRetry), 'true'))"
+      Sources="@(Artifact)"
+      Condition="@(Artifact->Count()) > 0" />
+  </Target>
+
+  <Target Name="RobocopyFiles"
+          Condition="'$(EnableArtifacts)' != 'false'"
+          AfterTargets="$([MSBuild]::ValueOrDefault($(RobocopyFilesAfterTargets), 'AfterBuild'))"
+          DependsOnTargets="$(RobocopyFilesDependsOn)">
+    <Robocopy
+      RetryCount="$([MSBuild]::ValueOrDefault($(RobocopyRetryCount), $(CopyRetryCount)))"
+      RetryWait="$([MSBuild]::ValueOrDefault($(RobocopyRetryWait), $(CopyRetryDelayMilliseconds)))"
+      ShowDiagnosticTrace="$(RobocopyShowDiagnosticTrace)"
+      ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(RobocopyShowErrorOnRetry), 'true'))"
+      Sources="@(Robocopy)"
+      Condition="@(Robocopy->Count()) > 0"/>
+  </Target>
+</Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.props
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.props
@@ -6,13 +6,14 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(CustomBeforeArtifactsProps)"
-          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomBeforeArtifactsProps)' != '' And Exists('$(CustomBeforeArtifactsProps)') " />
+          Condition="'$(CustomBeforeArtifactsProps)' != '' And Exists('$(CustomBeforeArtifactsProps)') " />
 
   <PropertyGroup>
-    <UsingMicrosoftArtifactsSdk>true</UsingMicrosoftArtifactsSdk>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Build.Artifacts.Common.props" />
   
   <Import Project="$(CustomAfterArtifactsProps)"
-          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomAfterArtifactsProps)' != '' And Exists('$(CustomAfterArtifactsProps)') " />
+          Condition="'$(CustomAfterArtifactsProps)' != '' And Exists('$(CustomAfterArtifactsProps)') " />
 </Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.targets
@@ -6,69 +6,26 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(CustomBeforeArtifactsTargets)"
-          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomBeforeArtifactsTargets)' != '' And Exists('$(CustomBeforeArtifactsTargets)') " />
+          Condition="'$(CustomBeforeArtifactsTargets)' != '' And Exists('$(CustomBeforeArtifactsTargets)')" />
 
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <UsingTask TaskName="Robocopy"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net46\Microsoft.Build.Artifacts.dll'))"
-             Condition="'$(MSBuildRuntimeType)' != 'Core'" />
-  <UsingTask TaskName="Robocopy"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netcoreapp2.1\Microsoft.Build.Artifacts.dll'))"
-             Condition="'$(MSBuildRuntimeType)' == 'Core'" />
-
-  <ItemDefinitionGroup>
-    <Robocopy>
-      <Visible>false</Visible>
-      <VerifyExists>true</VerifyExists>
-    </Robocopy>
-    <Artifact>
-      <Visible>false</Visible>
-      <VerifyExists>true</VerifyExists>
-    </Artifact>
-  </ItemDefinitionGroup>
-
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != ''">
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != '' And '$(TargetFrameworks)' == ''">
     <!--
       By default copy the contents of $(DefaultArtifactsSource) (default is $(OutputPath)) to $(ArtifactsPath) unless:
        * EnableDefaultArtifacts is 'false'
        * $(ArtifactsPath) is not specified
+       * $(TargetFramworks) is specified in which case the artifacts are copied in the outer build
     -->
     <Artifact Include="$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))"
                DestinationFolder="$(ArtifactsPath)"
-               FileMatch="$([MSBuild]::ValueOrDefault($(DefaultArtifactsFileMatch), '*exe *dll *exe.config'))" />
+               FileMatch="$([MSBuild]::ValueOrDefault($(DefaultArtifactsFileMatch), '*exe *dll *exe.config *nupkg'))" />
   </ItemGroup>
 
-  <Target Name="CopyArtifacts"
-          AfterTargets="$([MSBuild]::ValueOrDefault($(CopyArtifactsAfterTargets), 'AfterBuild'))"
-          DependsOnTargets="$(CopyArtifactsDependsOn)">
-
-    <Robocopy
-      RetryCount="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryCount), $(CopyRetryCount)))"
-      RetryWait="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryDelayMilliseconds), $(CopyRetryDelayMilliseconds)))"
-      ShowDiagnosticTrace="$(ArtifactsShowDiagnostics)"
-      ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(ArtifactsShowErrorOnRetry), 'true'))"
-      Sources="@(Artifact)"
-      Condition="@(Artifact->Count()) > 0" />
-
-  </Target>
-
-  <Target Name="RobocopyFiles"
-          AfterTargets="$([MSBuild]::ValueOrDefault($(RobocopyFilesAfterTargets), 'AfterBuild'))"
-          DependsOnTargets="$(RobocopyFilesDependsOn)">
-
-    <Robocopy
-      RetryCount="$([MSBuild]::ValueOrDefault($(RobocopyRetryCount), $(CopyRetryCount)))"
-      RetryWait="$([MSBuild]::ValueOrDefault($(RobocopyRetryWait), $(CopyRetryDelayMilliseconds)))"
-      ShowDiagnosticTrace="$(RobocopyShowDiagnosticTrace)"
-      ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(RobocopyShowErrorOnRetry), 'true'))"
-      Sources="@(Robocopy)"
-      Condition="@(Robocopy->Count()) > 0"/>
-
-  </Target>
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.Build.Artifacts.Common.targets" />
 
   <Import Project="$(CustomAfterArtifactsTargets)"
-          Condition=" '$(EnableArtifacts)' != 'false' And '$(CustomAfterArtifactsTargets)' != '' And Exists('$(CustomAfterArtifactsTargets)') " />
+          Condition="'$(CustomAfterArtifactsTargets)' != '' And Exists('$(CustomAfterArtifactsTargets)')" />
 </Project>

--- a/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.props
+++ b/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.props
@@ -5,8 +5,15 @@
   Licensed under the MIT license.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CustomBeforeArtifactsProps)"
+          Condition="'$(CustomBeforeArtifactsProps)' != '' And Exists('$(CustomBeforeArtifactsProps)') " />
+
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  <Import Project="..\build\Microsoft.Build.Artifacts.props" />
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.Build.Artifacts.Common.props" />
+
+  <Import Project="$(CustomAfterArtifactsProps)"
+          Condition="'$(CustomAfterArtifactsProps)' != '' And Exists('$(CustomAfterArtifactsProps)') " />
 </Project>

--- a/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.targets
@@ -5,8 +5,26 @@
   Licensed under the MIT license.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(CustomBeforeArtifactsTargets)"
+          Condition="'$(CustomBeforeArtifactsTargets)' != '' And Exists('$(CustomBeforeArtifactsTargets)')" />
+
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
-  <Import Project="..\build\Microsoft.Build.Artifacts.targets" />
+
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != ''">
+    <!--
+      By default copy the contents of $(DefaultArtifactsSource) (default is $(OutputPath)) to $(ArtifactsPath) unless:
+       * EnableDefaultArtifacts is 'false'
+       * $(ArtifactsPath) is not specified
+    -->
+    <Artifact Include="$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))"
+              DestinationFolder="$(ArtifactsPath)"
+              FileMatch="$([MSBuild]::ValueOrDefault($(DefaultArtifactsFileMatch), '*exe *dll *exe.config *nupkg'))" />
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\build\Microsoft.Build.Artifacts.Common.targets" />
+
+  <Import Project="$(CustomAfterArtifactsTargets)"
+          Condition="'$(CustomAfterArtifactsTargets)' != '' And Exists('$(CustomAfterArtifactsTargets)')" />
 </Project>


### PR DESCRIPTION
When a project targets multiple target frameworks, we want the artifacts to be copied after the outer build and not for each inner build by default.  We also want the copy artifacts target to run after Pack if a pack is taking place.