### PR TITLE
Fix AfterTargets for multi-targeting projects

### DIFF
--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -7,11 +7,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
-
-    <!--
-      Copy artifacts after Pack if GeneratePackageOnBuild is true
-    -->
-    <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == '' And '$(GeneratePackageOnBuild)' == 'true'">Pack</CopyArtifactsAfterTargets>
   </PropertyGroup>
 
 

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.targets
@@ -10,6 +10,11 @@
 
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!--
+      Copy artifacts after Pack if GeneratePackageOnBuild is true
+    -->
+    <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == '' And '$(GeneratePackageOnBuild)' == 'true'">Pack</CopyArtifactsAfterTargets>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != '' And '$(TargetFrameworks)' == ''">

--- a/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.targets
@@ -10,6 +10,16 @@
 
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+
+    <!--
+      Copy artifacts after Pack if GeneratePackageOnBuild is true
+    -->
+    <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == '' And '$(GeneratePackageOnBuild)' == 'true'">_PackAsBuildAfterTarget</CopyArtifactsAfterTargets>
+
+    <!--
+      Copy artifacts after Build since there is no AfterBuild target in multi-targeting projects.
+    -->
+    <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == ''">Build</CopyArtifactsAfterTargets>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != ''">


### PR DESCRIPTION
Default AfterTargets of AfterBuild won't work for multi-targeting projects because there is no AfterBuild target.

Instead, the CopyArtifacts target should run after Build or _PackAsBuildAfterTarget depending on whether or not the project generates a package.

Fixes #151 