### PR TITLE
Do not import Microsoft.Managed.targets in older versions of MSBuild.

### DIFF
--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -72,9 +72,9 @@
   <Import Project="$(CustomAfterNoTargets)" Condition="'$(CustomAfterNoTargets)' != '' and Exists('$(CustomAfterNoTargets)')" />
 
   <!-- 
-    Microsoft.Managed.Targets is imported by the managed language target files, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
+    Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
     So import it when the managed targets do not get imported.
   -->
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets" Condition="'$(ManagedLanguageTargetsGotImported)' != 'true'"/>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets" Condition="'$(MSBuildAssemblyVersion)' >= '16.0' And '$(ManagedLanguageTargetsGotImported)' != 'true'" />
 
 </Project>


### PR DESCRIPTION
Microsoft.Managed.targets was added in MSBuild 16 so don't import it in MSBuild 15 and below

Fixes #147 