### PR TITLE
Fix default artifacts for non-multitargeting projects

### DIFF
--- a/src/Artifacts.UnitTests/ArtifactsTests.cs
+++ b/src/Artifacts.UnitTests/ArtifactsTests.cs
@@ -67,8 +67,10 @@ namespace Microsoft.Build.Artifacts.UnitTests
         [Fact]
         public void DefaultArtifactsUseOutputPath()
         {
-            DirectoryInfo outputPath = CreateFiles(
-                "bin",
+            DirectoryInfo baseOutputPath = CreateFiles(@"bin\Debug");
+
+            CreateFiles(
+                Path.Combine(baseOutputPath.FullName, "net472"),
                 "foo.exe",
                 "foo.pdb",
                 "foo.exe.config",
@@ -79,7 +81,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
             DirectoryInfo artifactsPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
 
             ProjectCreator.Templates.ProjectWithArtifacts(
-                outputPath: outputPath.FullName,
+                outputPath: baseOutputPath.FullName,
                 artifactsPath: artifactsPath.FullName)
                 .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
                 .TryBuild(out bool result, out BuildOutput buildOutput);
@@ -88,16 +90,54 @@ namespace Microsoft.Build.Artifacts.UnitTests
 
             ProjectItem artifactItem = artifactItems.ShouldHaveSingleItem();
 
-            artifactItem.EvaluatedInclude.ShouldBe(outputPath.FullName);
+            artifactItem.EvaluatedInclude.ShouldBe($"{baseOutputPath.FullName}{Path.DirectorySeparatorChar}");
             artifactItem.GetMetadataValue("DestinationFolder").ShouldBe(artifactsPath.FullName);
 
             artifactsPath.GetFiles("*", SearchOption.AllDirectories)
                 .Select(i => i.FullName)
                 .ShouldBe(new[]
                 {
-                    "bar.dll",
-                    "foo.exe",
-                    "foo.exe.config",
+                    @"net472\bar.dll",
+                    @"net472\foo.exe",
+                    @"net472\foo.exe.config",
+                }.Select(i => Path.Combine(artifactsPath.FullName, i)));
+        }
+
+        [Fact]
+        public void DefaultArtifactsUseOutputPathWithAppendTargetFrameworkToOutputPathFalse()
+        {
+            DirectoryInfo outputPath = CreateFiles(
+                @"bin\Debug",
+                "foo.exe",
+                "foo.pdb",
+                "foo.exe.config",
+                "bar.dll",
+                "bar.pdb",
+                "bar.cs");
+
+            DirectoryInfo artifactsPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
+
+            ProjectCreator.Templates.ProjectWithArtifacts(
+                    outputPath: outputPath.FullName,
+                    appendTargetFrameworkToOutputPath: false,
+                    artifactsPath: artifactsPath.FullName)
+                .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
+                .TryBuild(out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            ProjectItem artifactItem = artifactItems.ShouldHaveSingleItem();
+
+            artifactItem.EvaluatedInclude.ShouldBe($"{outputPath.FullName}{Path.DirectorySeparatorChar}");
+            artifactItem.GetMetadataValue("DestinationFolder").ShouldBe(artifactsPath.FullName);
+
+            artifactsPath.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(new[]
+                {
+                    @"bar.dll",
+                    @"foo.exe",
+                    @"foo.exe.config",
                 }.Select(i => Path.Combine(artifactsPath.FullName, i)));
         }
 
@@ -145,8 +185,10 @@ namespace Microsoft.Build.Artifacts.UnitTests
         [Fact]
         public void UsingSdkLogic()
         {
-            DirectoryInfo outputPath = CreateFiles(
-                "bin",
+            DirectoryInfo baseOutputPath = CreateFiles(@"bin\Debug");
+
+            CreateFiles(
+                Path.Combine(baseOutputPath.FullName, "net472"),
                 "foo.exe",
                 "foo.pdb",
                 "foo.exe.config",
@@ -157,7 +199,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
             DirectoryInfo artifactsPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
 
             ProjectCreator.Templates.SdkProjectWithArtifacts(
-                    outputPath: outputPath.FullName,
+                    outputPath: baseOutputPath.FullName,
                     artifactsPath: artifactsPath.FullName)
                 .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
                 .TryBuild(out bool result, out BuildOutput buildOutput);
@@ -166,16 +208,16 @@ namespace Microsoft.Build.Artifacts.UnitTests
 
             ProjectItem artifactItem = artifactItems.ShouldHaveSingleItem();
 
-            artifactItem.EvaluatedInclude.ShouldBe(outputPath.FullName);
+            artifactItem.EvaluatedInclude.ShouldBe($"{baseOutputPath.FullName}{Path.DirectorySeparatorChar}");
             artifactItem.GetMetadataValue("DestinationFolder").ShouldBe(artifactsPath.FullName);
 
             artifactsPath.GetFiles("*", SearchOption.AllDirectories)
                 .Select(i => i.FullName)
                 .ShouldBe(new[]
                 {
-                    "bar.dll",
-                    "foo.exe",
-                    "foo.exe.config",
+                    @"net472\bar.dll",
+                    @"net472\foo.exe",
+                    @"net472\foo.exe.config",
                 }.Select(i => Path.Combine(artifactsPath.FullName, i)));
         }
     }

--- a/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
@@ -40,6 +40,8 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     this ProjectCreatorTemplates templates,
             string outputPath = null,
             string artifactsPath = null,
+            string targetFramework = "net472",
+            bool? appendTargetFrameworkToOutputPath = true,
             Action<ProjectCreator> customAction = null,
             string path = null,
             string defaultTargets = null,
@@ -61,7 +63,10 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     projectFileOptions)
                 .Property("ArtifactsTaskAssembly", ArtifactsTaskAssembly)
                 .Import(Path.Combine(CurrentDirectory, "build", "Microsoft.Build.Artifacts.props"))
-                .Property("OutputPath", outputPath)
+                .Property("TargetFramework", targetFramework)
+                .Property("OutputPath", outputPath == null ? null : $"{outputPath.TrimEnd('\\')}\\")
+                .Property("AppendTargetFrameworkToOutputPath", appendTargetFrameworkToOutputPath.HasValue ? appendTargetFrameworkToOutputPath.ToString() : null)
+                .Property("OutputPath", "$(OutputPath)$(TargetFramework.ToLowerInvariant())\\", condition: "'$(AppendTargetFrameworkToOutputPath)' == 'true'")
                 .Property("ArtifactsPath", artifactsPath)
                 .CustomAction(customAction)
                 .Target("Build")
@@ -73,6 +78,8 @@ namespace Microsoft.Build.Artifacts.UnitTests
             this ProjectCreatorTemplates templates,
             string outputPath = null,
             string artifactsPath = null,
+            string targetFramework = "net472",
+            bool? appendTargetFrameworkToOutputPath = true,
             Action<ProjectCreator> customAction = null,
             string path = null,
             string defaultTargets = null,
@@ -94,7 +101,10 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     projectFileOptions)
                 .Property("ArtifactsTaskAssembly", ArtifactsTaskAssembly)
                 .Import(Path.Combine(CurrentDirectory, "Sdk", "Sdk.props"))
-                .Property("OutputPath", outputPath)
+                .Property("TargetFramework", targetFramework)
+                .Property("OutputPath", $"{outputPath.TrimEnd('\\')}\\")
+                .Property("AppendTargetFrameworkToOutputPath", appendTargetFrameworkToOutputPath.HasValue ? appendTargetFrameworkToOutputPath.ToString() : null)
+                .Property("OutputPath", "$(OutputPath)$(TargetFramework.ToLowerInvariant())\\", condition: "'$(AppendTargetFrameworkToOutputPath)' == 'true'")
                 .Property("ArtifactsPath", artifactsPath)
                 .CustomAction(customAction)
                 .Target("Build")

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.targets
@@ -17,14 +17,22 @@
     <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == '' And '$(GeneratePackageOnBuild)' == 'true'">Pack</CopyArtifactsAfterTargets>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != '' And '$(TargetFrameworks)' == ''">
+   <PropertyGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(DefaultArtifactsSource)' == '' And '$(TargetFrameworks)' == ''">
+      <!--
+         Default artifacts source is the output path unless AppendTargetFrameworkToOutputPath is true in which case the parent folder is the default.
+       -->
+      <DefaultArtifactsSource Condition="'$(AppendTargetFrameworkToOutputPath)' != 'true'">$(OutputPath)</DefaultArtifactsSource>
+      <DefaultArtifactsSource Condition="'$(AppendTargetFrameworkToOutputPath)' == 'true'">$([System.IO.Path]::GetDirectoryName($(OutputPath.TrimEnd('\'))))\</DefaultArtifactsSource>
+   </PropertyGroup>
+
+  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$(DefaultArtifactsSource)' != '' And '$(TargetFrameworks)' == ''">
     <!--
       By default copy the contents of $(DefaultArtifactsSource) (default is $(OutputPath)) to $(ArtifactsPath) unless:
        * EnableDefaultArtifacts is 'false'
        * $(ArtifactsPath) is not specified
        * $(TargetFramworks) is specified in which case the artifacts are copied in the outer build
     -->
-    <Artifact Include="$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))"
+    <Artifact Include="$(DefaultArtifactsSource)"
                DestinationFolder="$(ArtifactsPath)"
                FileMatch="$([MSBuild]::ValueOrDefault($(DefaultArtifactsFileMatch), '*exe *dll *exe.config *nupkg'))" />
   </ItemGroup>


### PR DESCRIPTION
When not multi-targeting, collect the entire output path and take into account that the AppendTargetFrameworkToOutputPath property appends the target framework.