### PR TITLE
Add BuildInParallel and ContinueOnError ext points

### DIFF
--- a/src/Traversal/README.md
+++ b/src/Traversal/README.md
@@ -83,3 +83,28 @@ Set some properties during build.
   </PropertyGroup>
 </Project>
 ```
+
+The following properties control the invocation of the to traversed projects.
+
+| Property                            | Description |
+|-------------------------------------|-------------|
+| `CleanInParallel` | BuildInParallel setting for the Clean target. |
+| `CleanContinueOnError` | ContinueOnError setting for the Clean target. |
+| `TestInParallel` | BuildInParallel setting for the Test and VSTest target. |
+| `TestContinueOnError` | ContinueOnError setting for the Test and VSTest target. |
+| `PackInParallel` | BuildInParallel setting for the Pack target. |
+| `PackContinueOnError` | ContinueOnError setting for the Pack target. |
+| `PublishInParallel` | BuildInParallel setting for the Publish target. |
+| `PublishContinueOnError` | ContinueOnError setting for the Publish target. |
+
+**Example**
+
+Change the `BuildInParallel` setting for the Test target.
+
+```xml
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TestInParallel>true</TestInParallel>
+  </PropertyGroup>
+</Project>
+```

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -104,7 +104,7 @@
 
   <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
-    <ContinueOnErrorCondition="'$(ContinueOnError)' == ''">false</ContinueOnError>
+    <ContinueOnError Condition="'$(ContinueOnError)' == ''">false</ContinueOnError>
   </PropertyGroup>
 
   <Target Name="PrepareForBuild"

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -102,6 +102,11 @@
     <ProjectReference Remove="$(MSBuildProjectFullPath)" />
   </ItemGroup>
 
+  <PropertyGroup>
+    <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
+    <ContinueOnErrorCondition="'$(ContinueOnError)' == ''">false</ContinueOnError>
+  </PropertyGroup>
+
   <Target Name="PrepareForBuild"
           DependsOnTargets="$(PrepareForBuildDependsOn)" />
 
@@ -120,10 +125,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Clean"
-             BuildInParallel="$([MSBuild]::ValueOrDefault('$(CleanInParallel)', '$(BuildInParallel)')"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(CleanInParallel)', '$(BuildInParallel)'))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$([MSBuild]::ValueOrDefault('$(CleanContinueOnError)', '$(ContinueOnError)')" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(CleanContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="Test"
@@ -131,10 +136,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Test"
-             BuildInParallel="$([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)')"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)')" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="VSTest"
@@ -142,10 +147,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="VSTest"
-             BuildInParallel="$([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)')"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)')" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="Pack"
@@ -153,10 +158,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Pack"
-             BuildInParallel="$([MSBuild]::ValueOrDefault('$(PackInParallel)', '$(BuildInParallel)')"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(PackInParallel)', '$(BuildInParallel)'))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$([MSBuild]::ValueOrDefault('$(PackContinueOnError)', '$(ContinueOnError)')" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(PackContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="Publish"
@@ -165,10 +170,10 @@
     <MSBuild Projects="@(ProjectReference)"
              Properties="$(TraversalPublishGlobalProperties)"
              Targets="Publish"
-             BuildInParallel="$([MSBuild]::ValueOrDefault('$(PublishInParallel)', '$(BuildInParallel)')"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(PublishInParallel)', '$(BuildInParallel)'))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$([MSBuild]::ValueOrDefault('$(PublishContinueOnError)', '$(ContinueOnError)')" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(PublishContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <!--

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -101,21 +101,6 @@
     -->
     <ProjectReference Remove="$(MSBuildProjectFullPath)" />
   </ItemGroup>
-  
-  <!-- Fine grained control of BuildInParallel and ContinueOnError. -->
-  <PropertyGroup>
-    <CleanInParallel Condition="'$(CleanInParallel)' == ''">$(BuildInParallel)</CleanInParallel>
-    <CleanContinueOnError Condition="'$(CleanContinueOnError)' == ''">$(ContinueOnError)</CleanContinueOnError>
-
-    <TestInParallel Condition="'$(TestInParallel)' == ''">$(BuildInParallel)</TestInParallel>
-    <TestContinueOnError Condition="'$(TestContinueOnError)' == ''">$(ContinueOnError)</TestContinueOnError>
-
-    <PackInParallel Condition="'$(PackInParallel)' == ''">$(BuildInParallel)</PackInParallel>
-    <PackContinueOnError Condition="'$(PackContinueOnError)' == ''">$(ContinueOnError)</PackContinueOnError>
-
-    <PublishInParallel Condition="'$(PublishInParallel)' == ''">$(BuildInParallel)</PublishInParallel>
-    <PublishContinueOnError Condition="'$(PublishContinueOnError)' == ''">$(ContinueOnError)</PublishContinueOnError>
-  </PropertyGroup>
 
   <Target Name="PrepareForBuild"
           DependsOnTargets="$(PrepareForBuildDependsOn)" />
@@ -128,9 +113,6 @@
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
              ContinueOnError="$(ContinueOnError)" />
-    
-    <!-- If we ErrorAndContinue we need to propagate the error. -->
-    <Error Condition="'$(ContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
   </Target>
 
   <Target Name="Clean"
@@ -138,13 +120,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Clean"
-             BuildInParallel="$(CleanInParallel)"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(CleanInParallel)', '$(BuildInParallel)')"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$(CleanContinueOnError)" />
-
-    <!-- If we ErrorAndContinue we need to propagate the error. -->
-    <Error Condition="'$(CleanContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(CleanContinueOnError)', '$(ContinueOnError)')" />
   </Target>
 
   <Target Name="Test"
@@ -152,13 +131,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Test"
-             BuildInParallel="$(TestInParallel)"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)')"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$(TestContinueOnError)" />
-
-    <!-- If we ErrorAndContinue we need to propagate the error. -->
-    <Error Condition="'$(TestContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)')" />
   </Target>
 
   <Target Name="VSTest"
@@ -166,13 +142,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="VSTest"
-             BuildInParallel="$(TestInParallel)"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)')"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$(TestContinueOnError)" />
-
-    <!-- If we ErrorAndContinue we need to propagate the error. -->
-    <Error Condition="'$(TestContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)')" />
   </Target>
 
   <Target Name="Pack"
@@ -180,13 +153,10 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Pack"
-             BuildInParallel="$(PackInParallel)"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(PackInParallel)', '$(BuildInParallel)')"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$(PackContinueOnError)" />
-
-    <!-- If we ErrorAndContinue we need to propagate the error. -->
-    <Error Condition="'$(PackContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(PackContinueOnError)', '$(ContinueOnError)')" />
   </Target>
 
   <Target Name="Publish"
@@ -195,13 +165,10 @@
     <MSBuild Projects="@(ProjectReference)"
              Properties="$(TraversalPublishGlobalProperties)"
              Targets="Publish"
-             BuildInParallel="$(PublishInParallel)"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('$(PublishInParallel)', '$(BuildInParallel)')"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
-             ContinueOnError="$(PublishContinueOnError)" />
-
-    <!-- If we ErrorAndContinue we need to propagate the error. -->
-    <Error Condition="'$(PublishContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
+             ContinueOnError="$([MSBuild]::ValueOrDefault('$(PublishContinueOnError)', '$(ContinueOnError)')" />
   </Target>
 
   <!--

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -101,6 +101,21 @@
     -->
     <ProjectReference Remove="$(MSBuildProjectFullPath)" />
   </ItemGroup>
+  
+  <!-- Fine grained control of BuildInParallel and ContinueOnError. -->
+  <PropertyGroup>
+    <CleanInParallel Condition="'$(CleanInParallel)' == ''">$(BuildInParallel)</CleanInParallel>
+    <CleanContinueOnError Condition="'$(CleanContinueOnError)' == ''">$(ContinueOnError)</CleanContinueOnError>
+
+    <TestInParallel Condition="'$(TestInParallel)' == ''">$(BuildInParallel)</TestInParallel>
+    <TestContinueOnError Condition="'$(TestContinueOnError)' == ''">$(ContinueOnError)</TestContinueOnError>
+
+    <PackInParallel Condition="'$(PackInParallel)' == ''">$(BuildInParallel)</PackInParallel>
+    <PackContinueOnError Condition="'$(PackContinueOnError)' == ''">$(ContinueOnError)</PackContinueOnError>
+
+    <PublishInParallel Condition="'$(PublishInParallel)' == ''">$(BuildInParallel)</PublishInParallel>
+    <PublishContinueOnError Condition="'$(PublishContinueOnError)' == ''">$(ContinueOnError)</PublishContinueOnError>
+  </PropertyGroup>
 
   <Target Name="PrepareForBuild"
           DependsOnTargets="$(PrepareForBuildDependsOn)" />
@@ -111,7 +126,11 @@
     <MSBuild Projects="@(ProjectReference)"
              BuildInParallel="$(BuildInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+             SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             ContinueOnError="$(ContinueOnError)" />
+    
+    <!-- If we ErrorAndContinue we need to propagate the error. -->
+    <Error Condition="'$(ContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
   </Target>
 
   <Target Name="Clean"
@@ -119,9 +138,13 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Clean"
-             BuildInParallel="$(BuildInParallel)"
+             BuildInParallel="$(CleanInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+             SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             ContinueOnError="$(CleanContinueOnError)" />
+
+    <!-- If we ErrorAndContinue we need to propagate the error. -->
+    <Error Condition="'$(CleanContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
   </Target>
 
   <Target Name="Test"
@@ -129,9 +152,13 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Test"
-             BuildInParallel="$(BuildInParallel)"
+             BuildInParallel="$(TestInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+             SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             ContinueOnError="$(TestContinueOnError)" />
+
+    <!-- If we ErrorAndContinue we need to propagate the error. -->
+    <Error Condition="'$(TestContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
   </Target>
 
   <Target Name="VSTest"
@@ -139,9 +166,13 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="VSTest"
-             BuildInParallel="$(BuildInParallel)"
+             BuildInParallel="$(TestInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+             SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             ContinueOnError="$(TestContinueOnError)" />
+
+    <!-- If we ErrorAndContinue we need to propagate the error. -->
+    <Error Condition="'$(TestContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
   </Target>
 
   <Target Name="Pack"
@@ -149,9 +180,13 @@
           Condition=" '$(IsGraphBuild)' != 'true' ">
     <MSBuild Projects="@(ProjectReference)"
              Targets="Pack"
-             BuildInParallel="$(BuildInParallel)"
+             BuildInParallel="$(PackInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+             SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             ContinueOnError="$(PackContinueOnError)" />
+
+    <!-- If we ErrorAndContinue we need to propagate the error. -->
+    <Error Condition="'$(PackContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
   </Target>
 
   <Target Name="Publish"
@@ -160,9 +195,13 @@
     <MSBuild Projects="@(ProjectReference)"
              Properties="$(TraversalPublishGlobalProperties)"
              Targets="Publish"
-             BuildInParallel="$(BuildInParallel)"
+             BuildInParallel="$(PublishInParallel)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
-             SkipNonexistentTargets="$(SkipNonexistentTargets)" />
+             SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             ContinueOnError="$(PublishContinueOnError)" />
+
+    <!-- If we ErrorAndContinue we need to propagate the error. -->
+    <Error Condition="'$(PublishContinueOnError)' == 'ErrorAndContinue' and '$(MSBuildLastTaskResult)' == 'false'" />
   </Target>
 
   <!--


### PR DESCRIPTION
In dotnet/runtime we need more fine grained control over the `BuildInParallel` and `ContinueOnError` setting for the `Test` target. For the sake of consistency I added extension points for the other targets as well. 

For an example where in dotnet/runtime this is needed, see https://github.com/dotnet/runtime/blob/master/src/libraries/tests.proj.

cc @jeffkl