### PR TITLE
Fix AdditionalProperties overwrite in Traversal

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -89,9 +89,9 @@
     <ProjectFile Remove="@(ProjectFile)" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TraversalGlobalProperties)' != ''">
     <ProjectReference Update="@(ProjectReference)"
-                      AdditionalProperties="$(TraversalGlobalProperties)" />
+                      AdditionalProperties="%(AdditionalProperties);$(TraversalGlobalProperties)" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TraversalRemoveCurrentProject)' != 'false' ">


### PR DESCRIPTION
AdditionalProperties are currently always overwritten in ProjectReferences. Fixing that by adding to instead of setting the property.

@jeffkl can we please publish another release with this fix. Last time I'll nag you for this :)