### PR TITLE
Override CoreCompile

### DIFF
--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -82,4 +82,10 @@
   -->
   <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets" Condition="'$(MSBuildAssemblyVersion)' >= '16.0' And '$(ManagedLanguageTargetsGotImported)' != 'true'" />
 
+  <!-- Override stock CoreCompile target to do nothing but keep extensibility points -->
+  <Target Name="CoreCompile"
+          DependsOnTargets="$(CoreCompileDependsOn)">
+    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
This overrides CoreCompile since NoTargets shouldn't be calling the compiler.  It also makes sure the target exists so users don't get errors about it not existing.

Fixes #169