### PR TITLE
Add support to stop on first failure to traversal SDK

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -114,11 +114,23 @@
           DependsOnTargets="$(BuildDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' "
           Returns="@(CollectedBuildOutput)">
+
+    <ItemGroup>
+      <_buildInParallel Remove="@(_buildInParallel)" />
+      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)', '$(BuildInParallel)'))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
+      <StopOnFirstFailure>false</StopOnFirstFailure>
+      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
+    </PropertyGroup>
+
     <MSBuild Projects="@(ProjectReference)"
              Condition="'%(ProjectReference.Build)' != 'false'"
              BuildInParallel="$([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)', '$(BuildInParallel)'))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             StopOnFirstFailure="$(StopOnFirstFailure)"
              ContinueOnError="$(ContinueOnError)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput" />
     </MSBuild>
@@ -127,6 +139,21 @@
   <Target Name="Clean"
           DependsOnTargets="$(CleanDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
+    
+    <ItemGroup>
+      <_buildInParallel Remove="@(_buildInParallel)" />
+      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.CleanInParallel)',
+                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
+                                    $([MSBuild]::ValueOrDefault('$(CleanInParallel)', '$(BuildInParallel)'))
+                                    ))
+                                  ))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
+      <StopOnFirstFailure>false</StopOnFirstFailure>
+      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
+    </PropertyGroup>
+
     <MSBuild Projects="@(ProjectReference)"
              Targets="Clean"
              Condition="'%(ProjectReference.Clean)' != 'false'"
@@ -137,12 +164,28 @@
                                ))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             StopOnFirstFailure="$(StopOnFirstFailure)"
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(CleanContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="Test"
           DependsOnTargets="$(TestDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
+
+    <ItemGroup>
+      <_buildInParallel Remove="@(_buildInParallel)" />
+      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.TestInParallel)',
+                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
+                                    $([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))
+                                    ))
+                                  ))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
+      <StopOnFirstFailure>false</StopOnFirstFailure>
+      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
+    </PropertyGroup>
+
     <MSBuild Projects="@(ProjectReference)"
              Targets="Test"
              Condition="'%(ProjectReference.Test)' != 'false'"
@@ -153,12 +196,28 @@
                                ))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             StopOnFirstFailure="$(StopOnFirstFailure)"
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="VSTest"
           DependsOnTargets="$(VSTestDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
+
+    <ItemGroup>
+      <_buildInParallel Remove="@(_buildInParallel)" />
+      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.TestInParallel)',
+                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
+                                    $([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))
+                                    ))
+                                  ))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
+      <StopOnFirstFailure>false</StopOnFirstFailure>
+      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
+    </PropertyGroup>
+
     <MSBuild Projects="@(ProjectReference)"
              Targets="VSTest"
              Condition="'%(ProjectReference.Test)' != 'false'"
@@ -169,12 +228,28 @@
                                ))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             StopOnFirstFailure="$(StopOnFirstFailure)"
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(TestContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="Pack"
           DependsOnTargets="$(PackDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
+    
+    <ItemGroup>
+      <_buildInParallel Remove="@(_buildInParallel)" />
+      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.PackInParallel)',
+                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
+                                    $([MSBuild]::ValueOrDefault('$(PackInParallel)', '$(BuildInParallel)'))
+                                    ))
+                                  ))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
+      <StopOnFirstFailure>false</StopOnFirstFailure>
+      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
+    </PropertyGroup>
+
     <MSBuild Projects="@(ProjectReference)"
              Targets="Pack"
              Condition="'%(ProjectReference.Pack)' != 'false'"
@@ -185,12 +260,28 @@
                                ))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             StopOnFirstFailure="$(StopOnFirstFailure)"
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(PackContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
   <Target Name="Publish"
           DependsOnTargets="$(PublishDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
+
+    <ItemGroup>
+      <_buildInParallel Remove="@(_buildInParallel)" />
+      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.PublishInParallel)',
+                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
+                                    $([MSBuild]::ValueOrDefault('$(PublishInParallel)', '$(BuildInParallel)'))
+                                    ))
+                                  ))" />
+    </ItemGroup>
+
+    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
+      <StopOnFirstFailure>false</StopOnFirstFailure>
+      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
+    </PropertyGroup>
+
     <MSBuild Projects="@(ProjectReference)"
              Properties="$(TraversalPublishGlobalProperties)"
              Targets="Publish"
@@ -202,6 +293,7 @@
                                ))"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             StopOnFirstFailure="$(StopOnFirstFailure)"
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(PublishContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -105,6 +105,7 @@
   <PropertyGroup>
     <BuildInParallel Condition="'$(BuildInParallel)' == ''">true</BuildInParallel>
     <ContinueOnError Condition="'$(ContinueOnError)' == ''">false</ContinueOnError>
+    <StopOnFirstFailure Condition="'$(StopOnFirstFailure)' == ''">true</StopOnFirstFailure>
   </PropertyGroup>
 
   <Target Name="PrepareForBuild"
@@ -114,17 +115,6 @@
           DependsOnTargets="$(BuildDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' "
           Returns="@(CollectedBuildOutput)">
-
-    <ItemGroup>
-      <_buildInParallel Remove="@(_buildInParallel)" />
-      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)', '$(BuildInParallel)'))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
-      <StopOnFirstFailure>false</StopOnFirstFailure>
-      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
-    </PropertyGroup>
-
     <MSBuild Projects="@(ProjectReference)"
              Condition="'%(ProjectReference.Build)' != 'false'"
              BuildInParallel="$([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)', '$(BuildInParallel)'))"
@@ -139,21 +129,6 @@
   <Target Name="Clean"
           DependsOnTargets="$(CleanDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
-    
-    <ItemGroup>
-      <_buildInParallel Remove="@(_buildInParallel)" />
-      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.CleanInParallel)',
-                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
-                                    $([MSBuild]::ValueOrDefault('$(CleanInParallel)', '$(BuildInParallel)'))
-                                    ))
-                                  ))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
-      <StopOnFirstFailure>false</StopOnFirstFailure>
-      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
-    </PropertyGroup>
-
     <MSBuild Projects="@(ProjectReference)"
              Targets="Clean"
              Condition="'%(ProjectReference.Clean)' != 'false'"
@@ -171,21 +146,6 @@
   <Target Name="Test"
           DependsOnTargets="$(TestDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
-
-    <ItemGroup>
-      <_buildInParallel Remove="@(_buildInParallel)" />
-      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.TestInParallel)',
-                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
-                                    $([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))
-                                    ))
-                                  ))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
-      <StopOnFirstFailure>false</StopOnFirstFailure>
-      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
-    </PropertyGroup>
-
     <MSBuild Projects="@(ProjectReference)"
              Targets="Test"
              Condition="'%(ProjectReference.Test)' != 'false'"
@@ -203,21 +163,6 @@
   <Target Name="VSTest"
           DependsOnTargets="$(VSTestDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
-
-    <ItemGroup>
-      <_buildInParallel Remove="@(_buildInParallel)" />
-      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.TestInParallel)',
-                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
-                                    $([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))
-                                    ))
-                                  ))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
-      <StopOnFirstFailure>false</StopOnFirstFailure>
-      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
-    </PropertyGroup>
-
     <MSBuild Projects="@(ProjectReference)"
              Targets="VSTest"
              Condition="'%(ProjectReference.Test)' != 'false'"
@@ -235,21 +180,6 @@
   <Target Name="Pack"
           DependsOnTargets="$(PackDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
-    
-    <ItemGroup>
-      <_buildInParallel Remove="@(_buildInParallel)" />
-      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.PackInParallel)',
-                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
-                                    $([MSBuild]::ValueOrDefault('$(PackInParallel)', '$(BuildInParallel)'))
-                                    ))
-                                  ))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
-      <StopOnFirstFailure>false</StopOnFirstFailure>
-      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
-    </PropertyGroup>
-
     <MSBuild Projects="@(ProjectReference)"
              Targets="Pack"
              Condition="'%(ProjectReference.Pack)' != 'false'"
@@ -267,21 +197,6 @@
   <Target Name="Publish"
           DependsOnTargets="$(PublishDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">
-
-    <ItemGroup>
-      <_buildInParallel Remove="@(_buildInParallel)" />
-      <_buildInParallel Include="$([MSBuild]::ValueOrDefault('%(ProjectReference.PublishInParallel)',
-                                  $([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)',
-                                    $([MSBuild]::ValueOrDefault('$(PublishInParallel)', '$(BuildInParallel)'))
-                                    ))
-                                  ))" />
-    </ItemGroup>
-
-    <PropertyGroup Condition="'$(StopOnFirstFailure)' == '' or '$(StopOnFirstFailure)' == 'true'">
-      <StopOnFirstFailure>false</StopOnFirstFailure>
-      <StopOnFirstFailure Condition="!@(_buildInParallel->AnyHaveMetadataValue('Identity', 'true'))">true</StopOnFirstFailure>
-    </PropertyGroup>
-
     <MSBuild Projects="@(ProjectReference)"
              Properties="$(TraversalPublishGlobalProperties)"
              Targets="Publish"


### PR DESCRIPTION
If you have 2 projects, let's say `A` and `B`, where `B` depends from `A` and you build them sequentially (not in parallel), if `A` fails, then `B` shouldn't be built.

We have cases like this in dotnet/runtime, where we have different partitions of the repo, like the runtime and libraries. Libraries build depends on the runtime build. For each partition we have a project that drives the build of that partition, and we have a "Driver" project which adds whatever partitions you're trying to build as projects to build using the Traversal SDK and we don't build them in parallel because they're dependent, so we need the ability of failing if any partition failed and stopping to get reasonable errors instead of errors due to the previous partition failing.

**I still need to add tests for this, but wanted to get early feedback**

cc: @rainersigwald 

FYI: @ViktorHofer 