### PR TITLE
Fix bubbling of TargetOutputs for "Rebuild" calls

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,6 @@ variables:
   BinaryLoggerArgs: '"/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
-  DotNetCoreVersion: '3.1.300'
 
 trigger:
   batch: true
@@ -33,9 +32,9 @@ jobs:
     vmImage: windows-latest
   steps:
   - task: UseDotNet@2
-    displayName: 'Install .NET Core $(DotNetCoreVersion)'
+    displayName: 'Install .NET Core from globa.json'
     inputs:
-      version: '$(DotNetCoreVersion)'
+      useGlobalJson: true
 
   - task: MSBuild@1
     displayName: 'Build Solution'

--- a/global.json
+++ b/global.json
@@ -1,4 +1,8 @@
 {
+  "sdk": {
+    "version": "3.1.300",
+    "rollForward": "latestFeature"
+  },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "1.0.94"
   }

--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -303,8 +303,11 @@ namespace Microsoft.Build.Traversal.UnitTests
             result.ShouldBeTrue(customMessage: () => buildOutput.GetConsoleLog());
         }
 
-        [Fact]
-        public void CollectsProjectReferenceBuildTargetOutputs()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("Build")]
+        [InlineData("Rebuild")]
+        public void CollectsProjectReferenceBuildTargetOutputs(string target)
         {
             string[] projects = new[]
             {
@@ -325,7 +328,7 @@ namespace Microsoft.Build.Traversal.UnitTests
                     parameters: new Dictionary<string, string>
                     {
                         ["Projects"] = subTraversalProject.FullPath,
-                        ["Targets"] = "Build"
+                        ["Targets"] = target
                     })
                 .TaskOutputItem("TargetOutputs", "CollectedOutputs")
                 .TaskMessage("%(CollectedOutputs.Identity)", MessageImportance.High)
@@ -342,6 +345,7 @@ namespace Microsoft.Build.Traversal.UnitTests
                                     .Target("Build", returns: "@(TestReturnItem)")
                                     .TargetItemGroup()
                                     .TargetItemInclude("TestReturnItem", "$(MSBuildThisFileName).dll")
+                                    .Target("Clean")
                                     .Save();
             }
         }

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -140,6 +140,8 @@
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(CleanContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
 
+  <Target Name="Rebuild" DependsOnTargets="$(RebuildDependsOn)" Returns="@(CollectedBuildOutput)" />
+
   <Target Name="Test"
           DependsOnTargets="$(TestDependsOn)"
           Condition=" '$(IsGraphBuild)' != 'true' ">


### PR DESCRIPTION
I took the freedom to pin down the .NET SDK version via global.json - i used the same version specified in the AzDO pipeline.
.NET 5 Previews were failing builds with this codebase on my machine:
![image](https://user-images.githubusercontent.com/6466560/84601217-ecca1380-ae7e-11ea-9a6c-415544e3538c.png)
Further explanation in the respective commit message.

I hope the additional change is cool with you ;)