### PR TITLE
Capture cross-targeting build TargetOutputs

### DIFF
--- a/src/Traversal/Sdk/CapturedBuildOutputCrossTargetingTargets.targets
+++ b/src/Traversal/Sdk/CapturedBuildOutputCrossTargetingTargets.targets
@@ -1,0 +1,6 @@
+<!-- Overriding the common Build target to capture inner outputs: https://github.com/microsoft/msbuild/issues/2148. -->
+<Project>
+  <Target Name="Build" 
+          DependsOnTargets="_SetBuildInnerTarget;DispatchToInnerBuilds" 
+          Returns="@(InnerOutput)" />
+</Project>

--- a/src/Traversal/Sdk/Sdk.props
+++ b/src/Traversal/Sdk/Sdk.props
@@ -8,6 +8,7 @@
 
   <PropertyGroup>
     <UsingMicrosoftTraversalSdk>true</UsingMicrosoftTraversalSdk>
+    <CustomAfterMicrosoftCommonCrossTargetingTargets>$(CustomAfterMicrosoftCommonCrossTargetingTargets);$(MSBuildThisFileDirectory)CapturedBuildOutputCrossTargetingTargets.targets</CustomAfterMicrosoftCommonCrossTargetingTargets>
   </PropertyGroup>
 
   <Import Project="$(CustomBeforeTraversalProps)" Condition=" '$(CustomBeforeTraversalProps)' != '' And Exists('$(CustomBeforeTraversalProps)') " />


### PR DESCRIPTION
With https://github.com/microsoft/MSBuildSdks/commit/9dca0b7884bde58d16eff4a41359bf36230bd368, capturing the build output is now possible but `CollectedBuildOutput` does not include output from cross-targeting projects. Overriding the Common target's Build output to allow that.

cc @MeikTranel @jeffkl 