### PR TITLE
Disable target framework validation in NoTargets

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -20,6 +20,25 @@ namespace Microsoft.Build.NoTargets.UnitTests
     public class NoTargetsTests : MSBuildSdkTestBase
     {
         [Fact]
+        public void DoNotReferenceOutputAssemblies()
+        {
+            ProjectCreator projectA = ProjectCreator.Templates.SdkCsproj(
+                    path: Path.Combine(TestRootPath, "ProjectA", "ProjectA.csproj"),
+                    targetFramework: "netcoreapp2.1")
+                .Save();
+
+            ProjectCreator noTargetsProject = ProjectCreator.Templates.NoTargetsProject(
+                    path: Path.Combine(TestRootPath, "NoTargets", "NoTargets.csproj"),
+                    targetFramework: "net45")
+                .ItemProjectReference(projectA)
+                .Save();
+
+            noTargetsProject.TryRestore(out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
         public void EnableDefaultCompileItemsIsFalse()
         {
             ProjectCreator.Templates.NoTargetsProject(

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -24,7 +24,23 @@
     <!-- Disable default Compile and EmbeddedResource items for NoTargets projects -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+
+    <!--
+      NuGet should always restore Traversal projects with "PackageReference" style restore.  Setting this property will cause the right thing to happen even if there aren't any PackageReference items in the project.
+    -->
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
   </PropertyGroup>
+
+  <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">
+    <ProjectReference>
+      <!--
+        Setting ReferenceOutputAssembly skips target framework cross-project validation in NuGet.  Since NoTargets projects don't define runtime
+        constraints like a target framework, there's no point in checking the compatibilty of project references.
+      -->
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+      <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
+    </ProjectReference>
+  </ItemDefinitionGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>
 

--- a/src/NoTargets/version.json
+++ b/src/NoTargets/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "1.0"
+  "version": "2.0"
 }


### PR DESCRIPTION
Since NoTargets projects don't define runtime requirements like target framework, there is no point in checking compatibility.

Fixes #191