### PR TITLE
Fix restore in Traversal when TargetFrameworks property is set

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -18,6 +18,15 @@
     <OutputPath Condition=" '$(Configuration)' != '' And '$(Platform)' != '' ">bin\$(Configuration)\$(Platform)\</OutputPath>
   </PropertyGroup>
 
+  <!--
+    TargetFrameworks is used to convey that a project targets multiple frameworks.  Traversal does not support multi-targeting
+    but having this property set to a value can confuse NuGet leading to errors.  Setting the property to empty fixes an issue
+    where a user unknowningly sets it, breaking restore.  See also: https://github.com/microsoft/MSBuildSdks/issues/196
+  -->
+  <PropertyGroup>
+    <TargetFrameworks></TargetFrameworks>
+  </PropertyGroup>
+
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition=" Exists('$(MSBuildToolsPath)\Microsoft.Common.targets') " />
 
   <ItemGroup>

--- a/src/Traversal/version.json
+++ b/src/Traversal/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "2.0"
+  "version": "2.1"
 }


### PR DESCRIPTION
A breaking change in the .NET SDK now uses TargetFrameworks differently leading to restore errors when Traversal projects set it accidentally.

Traversal projects do not support multi-targeting by design, so this change just sets TargetFrameworks to empty to ensure that NuGet does not try to restore using multiple frameworks.

Fixes #196