### PR TITLE
Allow loading .msbuildproj in VS using Traversal SDK

### DIFF
--- a/src/Traversal/Sdk/Sdk.props
+++ b/src/Traversal/Sdk/Sdk.props
@@ -42,6 +42,9 @@
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
     </ProjectReference>
   </ItemDefinitionGroup>
+  
+  <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if needed -->
+  <Target Name="CompileDesignTime" />
 
   <Import Project="$(CustomAfterTraversalProps)" Condition=" '$(CustomAfterTraversalProps)' != '' And Exists('$(CustomAfterTraversalProps)') " />
 </Project>

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -229,5 +229,9 @@
   -->
   <Target Name="_CheckForInvalidConfigurationAndPlatform" />
 
+  <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
+  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
+          Condition="'$(DebuggerFlavor)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />
+
   <Import Project="$(CustomAfterTraversalTargets)" Condition=" '$(CustomAfterTraversalTargets)' != '' And Exists('$(CustomAfterTraversalTargets)') " />
 </Project>


### PR DESCRIPTION
By including the design-time targets and imports expected by CPS, we
allow the full loading and editing experience in the IDE automatically.

Fixes #206.

Same impl. already proven for NoTargets from #98.