### PR TITLE
Support .NET 5 SDK by importing its props and targets

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -49,6 +49,11 @@
           Visible="false" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <Content Include="$(MSBuildThisFileDirectory)xunit.runner.json"
+             CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
   <ItemGroup>
     <InternalsVisibleTo Update="@(InternalsVisibleTo)" Condition="'$(SignType)' == 'Test' Or '$(SignType)' == 'Real'" Key="002400000480000094000000060200000024000052534131000400000100010015c01ae1f50e8cc09ba9eac9147cf8fd9fce2cfe9f8dce4f7301c4132ca9fb50ce8cbf1df4dc18dd4d210e4345c744ecb3365ed327efdbc52603faa5e21daa11234c8c4a73e51f03bf192544581ebe107adee3a34928e39d04e524a9ce729d5090bfd7dad9d10c722c0def9ccc08ff0a03790e48bcd1f9b6c476063e1966a1c4" />
   </ItemGroup>

--- a/MSBuildSdks.sln
+++ b/MSBuildSdks.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DC479DC1
 		Packages.props = Packages.props
 		stylecop.json = stylecop.json
 		version.json = version.json
+		xunit.runner.json = xunit.runner.json
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Build.NoTargets", "src\NoTargets\Microsoft.Build.NoTargets.csproj", "{86A02D27-6A67-461B-931C-96051F363CAD}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,11 +53,25 @@ jobs:
       arguments: '$(MSBuildArgs)'
 
   - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests'
+    displayName: 'Run Unit Tests (.NET 5)'
     inputs:
       command: 'test'
-      arguments: '--no-restore --no-build "/restore:false"'
-      testRunTitle: 'Unit Tests'
+      arguments: '--no-restore --no-build --framework net5.0 "/restore:false"'
+      testRunTitle: '.NET v5.0'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET Framework)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net472 "/restore:false"'
+      testRunTitle: '.NET Framework v4.7.2'
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET Core)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework netcoreapp3.1 "/restore:false"'
+      testRunTitle: '.NET Core v3.1'
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifacts'

--- a/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
@@ -2,6 +2,7 @@
 //
 // Licensed under the MIT license.
 
+using Microsoft.Build.Artifacts.Tasks;
 using Microsoft.Build.Evaluation;
 using Microsoft.Build.Utilities.ProjectCreation;
 using System;
@@ -12,8 +13,9 @@ namespace Microsoft.Build.Artifacts.UnitTests
 {
     internal static class CustomProjectCreatorTemplates
     {
-        private static readonly string ArtifactsTaskAssembly = Path.Combine(Environment.CurrentDirectory, "Microsoft.Build.Artifacts.dll");
-        private static readonly string CurrentDirectory = Environment.CurrentDirectory;
+        private static readonly string ArtifactsTaskAssembly = typeof(Robocopy).Assembly.Location;
+
+        private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(ArtifactsTaskAssembly);
 
         public static ProjectCreator MultiTargetingProjectWithArtifacts(
             this ProjectCreatorTemplates templates,
@@ -28,12 +30,12 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     path: path,
                     projectCreator: creator => creator
                         .Property("ArtifactsTaskAssembly", ArtifactsTaskAssembly)
-                        .Import(Path.Combine(CurrentDirectory, "build", "Microsoft.Build.Artifacts.props"), condition: "'$(TargetFramework)' != ''")
-                        .Import(Path.Combine(CurrentDirectory, "buildMultiTargeting", "Microsoft.Build.Artifacts.props"), condition: "'$(TargetFramework)' == ''")
-                        .Property("ArtifactsPath", artifactsPath.FullName)
+                        .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.props"), condition: "'$(TargetFramework)' != ''")
+                        .Import(Path.Combine(ThisAssemblyDirectory, "buildMultiTargeting", "Microsoft.Build.Artifacts.props"), condition: "'$(TargetFramework)' == ''")
+                        .Property("ArtifactsPath", artifactsPath?.FullName)
                         .CustomAction(customAction)
-                        .Import(Path.Combine(CurrentDirectory, "build", "Microsoft.Build.Artifacts.targets"), condition: "'$(TargetFramework)' != ''")
-                        .Import(Path.Combine(CurrentDirectory, "buildMultiTargeting", "Microsoft.Build.Artifacts.targets"), condition: "'$(TargetFramework)' == ''"));
+                        .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.targets"), condition: "'$(TargetFramework)' != ''")
+                        .Import(Path.Combine(ThisAssemblyDirectory, "buildMultiTargeting", "Microsoft.Build.Artifacts.targets"), condition: "'$(TargetFramework)' == ''"));
         }
 
         public static ProjectCreator ProjectWithArtifacts(
@@ -62,7 +64,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     projectCollection,
                     projectFileOptions)
                 .Property("ArtifactsTaskAssembly", ArtifactsTaskAssembly)
-                .Import(Path.Combine(CurrentDirectory, "build", "Microsoft.Build.Artifacts.props"))
+                .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.props"))
                 .Property("TargetFramework", targetFramework)
                 .Property("OutputPath", outputPath == null ? null : $"{outputPath.TrimEnd('\\')}\\")
                 .Property("AppendTargetFrameworkToOutputPath", appendTargetFrameworkToOutputPath.HasValue ? appendTargetFrameworkToOutputPath.ToString() : null)
@@ -71,7 +73,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
                 .CustomAction(customAction)
                 .Target("Build")
                 .Target("AfterBuild", afterTargets: "Build")
-                .Import(Path.Combine(CurrentDirectory, "build", "Microsoft.Build.Artifacts.targets"));
+                .Import(Path.Combine(ThisAssemblyDirectory, "build", "Microsoft.Build.Artifacts.targets"));
         }
 
         public static ProjectCreator SdkProjectWithArtifacts(
@@ -100,7 +102,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     projectCollection,
                     projectFileOptions)
                 .Property("ArtifactsTaskAssembly", ArtifactsTaskAssembly)
-                .Import(Path.Combine(CurrentDirectory, "Sdk", "Sdk.props"))
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.props"))
                 .Property("TargetFramework", targetFramework)
                 .Property("OutputPath", $"{outputPath.TrimEnd('\\')}\\")
                 .Property("AppendTargetFrameworkToOutputPath", appendTargetFrameworkToOutputPath.HasValue ? appendTargetFrameworkToOutputPath.ToString() : null)
@@ -109,7 +111,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
                 .CustomAction(customAction)
                 .Target("Build")
                 .Target("AfterBuild", afterTargets: "Build")
-                .Import(Path.Combine(CurrentDirectory, "Sdk", "Sdk.targets"));
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.targets"));
         }
     }
 }

--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
+++ b/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
 {
     public class CentralPackageVersionsTests : MSBuildSdkTestBase
     {
+        private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(CustomProjectCreatorTemplates).Assembly.Location);
+
         [Theory]
         [InlineData(true, ".csproj")]
         [InlineData(true, ".sfproj")]
@@ -40,7 +42,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     }),
                     projectCreator: creator => creator
                         .Property("EnableCentralPackageVersions", "true")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryGetPropertyValue("EnableCentralPackageVersions", out string enableCentralPackageVersions);
 
             enableCentralPackageVersions.ShouldBe("true");
@@ -64,7 +66,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     }),
                     projectCreator: creator => creator
                         .ItemPackageReference("Foo", "10.0.0")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput)
                 .Project
                 .GetItems("PackageReference")
@@ -96,7 +98,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     }),
                     projectCreator: creator => creator
                         .ItemPackageReference("Foo")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput)
                 .Project
                 .GetItems("PackageReference")
@@ -134,7 +136,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                             {
                                 ["VersionOverride"] = "9.0.1",
                             })
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput)
                 .Project
                 .GetItems("PackageReference")
@@ -165,7 +167,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     }),
                     targetFramework: "net46",
                     projectCreator: creator => creator
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem> items);
 
             items.Where(i => i.EvaluatedInclude.Equals("FSharp.Core"))
@@ -183,7 +185,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                 .SdkCsproj(
                     path: Path.Combine(TestRootPath, "test.fsproj"),
                     projectCreator: creator => creator
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem> items);
 
             items.Where(i => i.EvaluatedInclude.Equals("FSharp.Core"))
@@ -204,7 +206,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     path: Path.Combine(TestRootPath, "test.fsproj"),
                     targetFramework: "net46",
                     projectCreator: creator => creator
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem> items);
 
             items.Where(i => i.EvaluatedInclude.Equals("FSharp.Core"))
@@ -241,7 +243,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                         ["DisableImplicitFrameworkReferences"] = "true",
                     }),
                     projectCreator: creator => creator
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryGetPropertyValue("EnableCentralPackageVersions", out string enableCentralPackageVersions);
 
             enableCentralPackageVersions.ShouldBe("false");
@@ -261,7 +263,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     projectCreator: creator => creator
                         .ItemPackageReference("Foo")
                         .ItemPackageReference("Global1")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeFalse(() => buildOutput.GetConsoleLog());
@@ -283,7 +285,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     projectCreator: creator => creator
                         .ItemPackageReference("Foo")
                         .ItemPackageReference("Baz")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeFalse(() => buildOutput.GetConsoleLog());
@@ -304,7 +306,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     path: Path.Combine(TestRootPath, $"test.{projectFileExtension}"),
                     projectCreator: creator => creator
                         .ItemPackageReference("Foo", "10.0.0")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeFalse(() => buildOutput.GetConsoleLog());
@@ -330,7 +332,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     }),
                     projectCreator: creator => creator
                         .ItemPackageReference("Foo", "10.0.0")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeFalse(() => buildOutput.GetConsoleLog());
@@ -350,7 +352,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     sdk: "Microsoft.NET.Sdk.Web",
                     projectCreator: creator => creator
                         .ItemPackageReference("Microsoft.AspNetCore.All")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem> items);
 
             items.Where(i => i.EvaluatedInclude.Equals("Microsoft.AspNetCore.All"))
@@ -371,7 +373,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     sdk: "Microsoft.NET.Sdk.Web",
                     projectCreator: creator => creator
                         .ItemPackageReference("Microsoft.AspNetCore.App")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryGetItems("PackageReference", out IReadOnlyCollection<ProjectItem> items);
 
             items.Where(i => i.EvaluatedInclude.Equals("Microsoft.AspNetCore.App"))
@@ -398,7 +400,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                     projectCreator: creator => creator
                         .ItemPackageReference("Foo")
                         .ItemPackageReference("Bar")
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .Project
                 .GetItems("PackageReference")
                     .Where(i => !i.EvaluatedInclude.Equals("FSharp.Core"))
@@ -434,7 +436,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                             {
                                 ["VersionOverride"] = "1.0.0",
                             })
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeTrue(() => buildOutput.GetConsoleLog());
@@ -463,7 +465,7 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
                             {
                                 ["VersionOverride"] = "1.0.0",
                             })
-                        .Import(Path.Combine(Environment.CurrentDirectory, @"Sdk\Sdk.targets")))
+                        .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets")))
                 .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeFalse(() => buildOutput.GetConsoleLog());

--- a/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
+++ b/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/CentralPackageVersions/Microsoft.Build.CentralPackageVersions.csproj
+++ b/src/CentralPackageVersions/Microsoft.Build.CentralPackageVersions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>Provides the ability to centrally manage your NuGet package versions when using PackageReference.</Description>
     <PackageTags>MSBuild MSBuildSdk</PackageTags>
     <ArtifactsPath>$(BaseArtifactsPath)\$(MSBuildProjectName)\</ArtifactsPath>

--- a/src/NoTargets.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/NoTargets.UnitTests/CustomProjectCreatorTemplates.cs
@@ -12,6 +12,8 @@ namespace Microsoft.Build.NoTargets.UnitTests
 {
     public static class CustomProjectCreatorTemplates
     {
+        private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(CustomProjectCreatorTemplates).Assembly.Location);
+
         public static ProjectCreator NoTargetsProject(
             this ProjectCreatorTemplates templates,
             Action<ProjectCreator> customAction = null,
@@ -26,8 +28,6 @@ namespace Microsoft.Build.NoTargets.UnitTests
             IDictionary<string, string> globalProperties = null,
             NewProjectFileOptions? projectFileOptions = NewProjectFileOptions.None)
         {
-            string currentDirectory = Environment.CurrentDirectory;
-
             return ProjectCreator.Create(
                     path,
                     defaultTargets,
@@ -38,10 +38,10 @@ namespace Microsoft.Build.NoTargets.UnitTests
                     projectCollection,
                     projectFileOptions,
                     globalProperties)
-                .Import(Path.Combine(currentDirectory, "Sdk", "Sdk.props"))
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.props"))
                 .Property("TargetFramework", targetFramework)
                 .CustomAction(customAction)
-                .Import(Path.Combine(currentDirectory, "Sdk", "Sdk.targets"));
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.targets"));
         }
     }
 }

--- a/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
+++ b/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NoTargets/Microsoft.Build.NoTargets.csproj
+++ b/src/NoTargets/Microsoft.Build.NoTargets.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>Provides targets for projects that do not compile an assembly.</Description>
     <PackageTags>MSBuild MSBuildSdk notargets notarget</PackageTags>
     <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>

--- a/src/Traversal.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/Traversal.UnitTests/CustomProjectCreatorTemplates.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Build.Traversal.UnitTests
 {
     public static class CustomProjectCreatorTemplates
     {
+        private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(CustomProjectCreatorTemplates).Assembly.Location);
+
         public static ProjectCreator TraversalProject(
             this ProjectCreatorTemplates templates,
             string[] projectReferences = null,
@@ -24,8 +26,6 @@ namespace Microsoft.Build.Traversal.UnitTests
             NewProjectFileOptions? projectFileOptions = NewProjectFileOptions.None,
             Action<ProjectCreator> customAction = null)
         {
-            string currentDirectory = Environment.CurrentDirectory;
-
             return ProjectCreator.Create(
                     path,
                     defaultTargets,
@@ -35,13 +35,13 @@ namespace Microsoft.Build.Traversal.UnitTests
                     treatAsLocalProperty,
                     projectCollection,
                     projectFileOptions)
-                .Import(Path.Combine(currentDirectory, "Sdk", "Sdk.props"))
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.props"))
                 .ForEach(projectReferences, (projectReference, i) =>
                 {
                     i.ItemProjectReference(projectReference);
                 })
                 .CustomAction(customAction)
-                .Import(Path.Combine(currentDirectory, "Sdk", "Sdk.targets"));
+                .Import(Path.Combine(ThisAssemblyDirectory, "Sdk", "Sdk.targets"));
         }
     }
 }

--- a/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
+++ b/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.Traversal.UnitTests
                 .TaskOutputItem("TargetOutputs", "CollectedOutputs")
                 .TaskMessage("%(CollectedOutputs.Identity)", MessageImportance.High)
                 .Save()
-                .TryBuild("BuildTraversalProject", out bool result, out BuildOutput buildOutput);
+                .TryBuild("BuildTraversalProject", out bool _, out BuildOutput buildOutput);
 
             buildOutput.Messages.High.ShouldContain("A.dll", customMessage: () => buildOutput.GetConsoleLog());
             buildOutput.Messages.High.ShouldContain("B.dll", customMessage: () => buildOutput.GetConsoleLog());

--- a/src/Traversal/Microsoft.Build.Traversal.csproj
+++ b/src/Traversal/Microsoft.Build.Traversal.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets">
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0</TargetFrameworks>
     <Description>Provides MSBuild traversal logic.</Description>
     <PackageTags>MSBuild MSBuildSdk traversal dirs</PackageTags>
     <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>

--- a/src/Traversal/Sdk/Sdk.props
+++ b/src/Traversal/Sdk/Sdk.props
@@ -12,7 +12,7 @@
 
   <Import Project="$(CustomBeforeTraversalProps)" Condition=" '$(CustomBeforeTraversalProps)' != '' And Exists('$(CustomBeforeTraversalProps)') " />
 
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' And Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') "/>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -25,9 +25,16 @@
   -->
   <PropertyGroup>
     <TargetFrameworks></TargetFrameworks>
+
+    <EnableDefaultItems>false</EnableDefaultItems>
+
+    <!-- 
+      TargetFramework is required for restore and used to default to .NET Framework v4.5.  However, Traversal projects don't specify a version so it needs to be defaulted here.
+    -->
+    <TargetFramework Condition="'$(TargetFramework)' == ''">net45</TargetFramework>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Common.targets" Condition=" Exists('$(MSBuildToolsPath)\Microsoft.Common.targets') " />
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <ItemGroup>
     <ProjectReferenceTargets Remove="@(ProjectReferenceTargets)" />

--- a/src/Traversal/version.json
+++ b/src/Traversal/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "2.2"
+  "version": "3.0"
 }

--- a/src/UnitTest.Common/MSBuildSdkTestBase.cs
+++ b/src/UnitTest.Common/MSBuildSdkTestBase.cs
@@ -6,12 +6,41 @@ using Microsoft.Build.Utilities.ProjectCreation;
 using System;
 using System.IO;
 using System.Linq;
+using System.Threading;
 
 namespace UnitTest.Common
 {
     public abstract class MSBuildSdkTestBase : MSBuildTestBase, IDisposable
     {
+        private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(MSBuildSdkTestBase).Assembly.Location);
+
         private readonly string _testRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+
+        public MSBuildSdkTestBase()
+        {
+            string globalJson = Path.Combine(TestRootPath, "global.json");
+#if NET50
+            File.WriteAllText(
+                globalJson,
+                @"{
+   ""sdk"": {
+    ""version"": ""5.0.100-preview"",
+    ""rollForward"": ""latestMinor"",
+    ""allowPrerelease"": true
+  },
+}");
+#else
+            File.WriteAllText(
+                globalJson,
+                @"{
+   ""sdk"": {
+    ""version"": ""3.1.400"",
+    ""rollForward"": ""latestMinor""
+  }
+}");
+#endif
+            Environment.CurrentDirectory = TestRootPath;
+        }
 
         public string TestRootPath
         {
@@ -46,6 +75,8 @@ namespace UnitTest.Common
         {
             if (disposing)
             {
+                Environment.CurrentDirectory = ThisAssemblyDirectory;
+
                 if (Directory.Exists(TestRootPath))
                 {
                     Directory.Delete(TestRootPath, recursive: true);

--- a/version.json
+++ b/version.json
@@ -1,6 +1,7 @@
 {
   "version": "1.0",
   "assemblyVersion": "1.0",
+  "buildNumberOffset": -1,
   "publicReleaseRefSpec": [
     "^refs/tags/Microsoft\\.Build.*"
   ],

--- a/xunit.runner.json
+++ b/xunit.runner.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "shadowCopy": false
+}


### PR DESCRIPTION
Previous versions of the .NET SDK did not require you to import them to get some of their build logic.  More and more of the logic is being moved out of what ships with MSBuild and into what ships in the SDK.  To that end, Traversal should import the Microsoft.NET.Sdk and just extend it.