### PR TITLE
Fix issue where Targets are not passed through

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -138,6 +138,7 @@
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
              StopOnFirstFailure="$(StopOnFirstFailure)"
+             Targets="%(ProjectReference.Targets)"
              ContinueOnError="$(ContinueOnError)">
       <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput" />
     </MSBuild>


### PR DESCRIPTION
When a user specifies the Targets metadata on a ProjectReference, they are not passed along to the MSBuild task.  Also added a unit test.

Fixes #214