### PR TITLE
Disable framework references in NoTargets projects

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -63,6 +63,18 @@ namespace Microsoft.Build.NoTargets.UnitTests
         }
 
         [Fact]
+        public void ImplicitFrameworkReferencesDisabledByDefault()
+        {
+            ProjectCreator noTargetsProject = ProjectCreator.Templates.NoTargetsProject(
+                    path: Path.Combine(TestRootPath, "NoTargets", "NoTargets.csproj"),
+                    targetFramework: "net45")
+                .Save()
+                .TryGetPropertyValue("DisableImplicitFrameworkReferences", out string disableImplicitFrameworkReferences);
+
+            disableImplicitFrameworkReferences.ShouldBe(bool.TrueString, StringCompareShould.IgnoreCase);
+        }
+
+        [Fact]
         public void IncludeBuildOutputIsFalseByDefault()
         {
             ProjectCreator.Templates.NoTargetsProject(

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -29,6 +29,9 @@
       NuGet should always restore Traversal projects with "PackageReference" style restore.  Setting this property will cause the right thing to happen even if there aren't any PackageReference items in the project.
     -->
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+
+    <!-- Targeting packs shouldn't be referenced as traversal projects don't compile. -->
+    <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">true</DisableImplicitFrameworkReferences>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">

--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -72,6 +72,20 @@ namespace Microsoft.Build.Traversal.UnitTests
             }
         }
 
+        [Fact]
+        public void ImplicitFrameworkReferencesDisabledByDefault()
+        {
+            ProjectCreator
+                .Templates
+                .TraversalProject(
+                    new string[0],
+                    path: GetTempFile("dirs.proj"))
+                .Save()
+                .TryGetPropertyValue("DisableImplicitFrameworkReferences", out string disableImplicitFrameworkReferences);
+
+            disableImplicitFrameworkReferences.ShouldBe(bool.TrueString, StringCompareShould.IgnoreCase);
+        }
+
         [Theory]
         [InlineData("dirs.proj")]
         [InlineData("Dirs.proj")]


### PR DESCRIPTION
Similar to #219, there's no need to require implicit framework references since NoTargets projects do not produce an assembly.

Also added unit test for Traversal