### PR TITLE
Fix extensibility of Compile and CoreCompile

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -19,6 +19,61 @@ namespace Microsoft.Build.NoTargets.UnitTests
 {
     public class NoTargetsTests : MSBuildSdkTestBase
     {
+        [Theory]
+        [InlineData("BeforeCompile")]
+        [InlineData("AfterCompile")]
+        public void CompileIsExtensibleWithBeforeAfterTargets(string targetName)
+        {
+            ProjectCreator noTargetsProject = ProjectCreator.Templates.NoTargetsProject(
+                    path: Path.Combine(TestRootPath, "NoTargets", "NoTargets.csproj"),
+                    targetFramework: "net45")
+                .Target(targetName)
+                .TaskMessage("503CF1EBA6DC415F95F4DB630E7C1817", MessageImportance.High)
+                .Save();
+
+            noTargetsProject.TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            buildOutput.Messages.High.ShouldContain("503CF1EBA6DC415F95F4DB630E7C1817", buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void CoreCompileIsExtensibleWithCoreCompileDependsOn()
+        {
+            ProjectCreator noTargetsProject = ProjectCreator.Templates.NoTargetsProject(
+                    path: Path.Combine(TestRootPath, "NoTargets", "NoTargets.csproj"),
+                    targetFramework: "net45")
+                .Property("CoreCompileDependsOn", "$(CoreCompileDependsOn);TestThatCoreCompileIsExtensible")
+                .Target("TestThatCoreCompileIsExtensible")
+                .TaskMessage("35F1C217730445E0AC0F30E70F5C7826", MessageImportance.High)
+                .Save();
+
+            noTargetsProject.TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            buildOutput.Messages.High.ShouldContain("35F1C217730445E0AC0F30E70F5C7826", buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void CoreCompileIsExtensibleWithTargetsTriggeredByCompilation()
+        {
+            ProjectCreator noTargetsProject = ProjectCreator.Templates.NoTargetsProject(
+                    path: Path.Combine(TestRootPath, "NoTargets", "NoTargets.csproj"),
+                    targetFramework: "net45")
+                .Property("TargetsTriggeredByCompilation", "TestThatCoreCompileIsExtensible")
+                .Target("TestThatCoreCompileIsExtensible")
+                    .TaskMessage("D031211C98F1454CA47A424ADC86A8F7", MessageImportance.High)
+                .Save();
+
+            noTargetsProject.TryBuild(restore: true, out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+
+            buildOutput.Messages.High.ShouldContain("D031211C98F1454CA47A424ADC86A8F7", buildOutput.GetConsoleLog());
+        }
+
         [Fact]
         public void DoNotReferenceOutputAssemblies()
         {

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -47,6 +47,7 @@
       PrepareForBuild;
       PreBuildEvent;
       ResolveReferences;
+      Compile;
       GetTargetPath;
       PrepareForRun;
       IncrementalClean;
@@ -88,4 +89,6 @@
     <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
   </Target>
 
+  <Target Name="_GenerateCompileInputs" />
+  <Target Name="_GenerateCompileDependencyCache" />
 </Project>

--- a/src/NoTargets/version.json
+++ b/src/NoTargets/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "2.0"
+  "version": "3.0"
 }


### PR DESCRIPTION
Compile was removed from BuildDependsOn to avoid having it run but this breaks some extensibility points that other SDKs might key off of.  This change brings back the dependency chain to run Compile and CoreCompile but has the bulk of their logic no-op.  This allows the extensibility to continue to work as expected.

Bumped version to 3.0 as this could be a breaking change.

Fixes #223 