### PR TITLE
Update Artifacts assembly path to netcoreapp3.1

### DIFF
--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -17,7 +17,7 @@
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net472\Microsoft.Build.Artifacts.dll'))"
              Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(MSBuildVersion)' &gt;= '16.0'" />
   <UsingTask TaskName="Robocopy"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netcoreapp2.1\Microsoft.Build.Artifacts.dll'))"
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netcoreapp3.1\Microsoft.Build.Artifacts.dll'))"
              Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(MSBuildVersion)' &lt; '16.8'" />
   <UsingTask TaskName="Robocopy"
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net5.0\Microsoft.Build.Artifacts.dll'))"


### PR DESCRIPTION
This fixes a FileNotFound exception when using Artifacts with a dotnetcore version < 5.0.

Support for target framework netcoreapp2.1 was dropped in favour of netcoreapp3.1 in #210, but the Robocopy build task here is still referencing a netcoreapp2.1 path which no longer exists. This has been replaced with the equivalent netcoreapp3.1 path.