### PR TITLE
Fix description to reflect what property the example is for

### DIFF
--- a/src/Traversal/README.md
+++ b/src/Traversal/README.md
@@ -99,7 +99,7 @@ The following properties control the invocation of the to traversed projects.
 
 **Example**
 
-Change the `BuildInParallel` setting for the Test target.
+Change the `TestInParallel` setting for the Test target.
 
 ```xml
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">


### PR DESCRIPTION
The example description didn't match the example