### PR TITLE
Clear two more items which are read by IDE and NuGet

### DIFF
--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -38,6 +38,12 @@
     <IntermediateRefAssembly Remove="@(IntermediateRefAssembly)" />
   </ItemGroup>
 
+  <!-- Clear output group items which are read by the IDE and NuGet. -->
+  <ItemGroup>
+    <BuiltProjectOutputGroupKeyOutput Remove="@(BuiltProjectOutputGroupKeyOutput)" />
+    <DebugSymbolsProjectOutputGroupOutput Remove="@(DebugSymbolsProjectOutputGroupOutput)" />
+  </ItemGroup>
+
   <PropertyGroup>
     <!--
       This property must be overridden to remove a few targets that compile assemblies


### PR DESCRIPTION
Clearing these items helps with IDE support but more importantly helps with some niche packaging scenarios when using the NoTargets.Sdk.

@jeffkl this helps with a very specific packaging case that we have in dotnet/runtime when using NoTargets.Sdk but I felt like because the IDE uses these items as well it makes sense to have this in the NoTargets.Sdk.