### PR TITLE
Disable GenerateAssemblyInfo and GenerateMSBuildEditorConfigFile

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -50,8 +50,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsTestProject)' == 'true'">
-    <Compile Include="$(MSBuildThisFileDirectory)src\Shared\MockTaskItem.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)src\Shared\MSBuildSdkTestBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)src\Shared\*.cs" />
+
     <Content Include="$(MSBuildThisFileDirectory)xunit.runner.json"
              CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>

--- a/MSBuildSdks.sln
+++ b/MSBuildSdks.sln
@@ -13,7 +13,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{DC479DC1
 		Directory.Build.rsp = Directory.Build.rsp
 		Directory.Build.targets = Directory.Build.targets
 		global.json = global.json
-		src\GlobalSuppressions.cs = src\GlobalSuppressions.cs
 		LICENSE.txt = LICENSE.txt
 		NuGet.config = NuGet.config
 		Packages.props = Packages.props

--- a/Packages.props
+++ b/Packages.props
@@ -8,7 +8,7 @@
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Update="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Update="MSBuild.ProjectCreation" Version="4.0.1" />
+    <PackageReference Update="MSBuild.ProjectCreation" Version="4.0.4" />
     <PackageReference Update="Shouldly" Version="4.0.3" />
     <PackageReference Update="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
     <PackageReference Update="xunit" Version="2.4.1" />
@@ -23,7 +23,7 @@
 
   <ItemGroup Condition=" '$(EnableStyleCop)' != 'false' ">
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
-    <Compile Include="..\GlobalSuppressions.cs" Visible="False" />
-    <AdditionalFiles Include="..\..\stylecop.json" Visible="False" />
+    <Compile Include="$(MSBuildThisFileDirectory)src\GlobalSuppressions.cs" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json" />
   </ItemGroup>
 </Project>

--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -93,65 +93,6 @@ namespace Microsoft.Build.NoTargets.UnitTests
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
         }
 
-        [Fact]
-        public void EnableDefaultCompileItemsIsFalse()
-        {
-            ProjectCreator.Templates.NoTargetsProject(
-                path: GetTempFileWithExtension(".csproj"))
-                .Property("GenerateDependencyFile", "false")
-                .Save()
-                .TryGetPropertyValue("EnableDefaultCompileItems", out string enableDefaultCompileItems);
-
-            enableDefaultCompileItems.ShouldBe("false");
-        }
-
-        [Fact]
-        public void EnableDefaultEmbeddedResourceItemsIsFalse()
-        {
-            ProjectCreator.Templates.NoTargetsProject(
-                path: GetTempFileWithExtension(".csproj"))
-                .Property("GenerateDependencyFile", "false")
-                .Save()
-                .TryGetPropertyValue("EnableDefaultEmbeddedResourceItems", out string enableDefaultEmbeddedResourceItems);
-
-            enableDefaultEmbeddedResourceItems.ShouldBe("false");
-        }
-
-        [Fact]
-        public void ImplicitFrameworkReferencesDisabledByDefault()
-        {
-            ProjectCreator.Templates.NoTargetsProject(
-                    path: Path.Combine(TestRootPath, "NoTargets", "NoTargets.csproj"),
-                    targetFramework: "net45")
-                .Save()
-                .TryGetPropertyValue("DisableImplicitFrameworkReferences", out string disableImplicitFrameworkReferences);
-
-            disableImplicitFrameworkReferences.ShouldBe(bool.TrueString, StringCompareShould.IgnoreCase);
-        }
-
-        [Fact]
-        public void IncludeBuildOutputIsFalseByDefault()
-        {
-            ProjectCreator.Templates.NoTargetsProject(
-                path: GetTempFileWithExtension(".csproj"))
-                .Save()
-                .TryGetPropertyValue("IncludeBuildOutput", out string includeBuildOutput);
-
-            includeBuildOutput.ShouldBe("false");
-        }
-
-        [Fact]
-        public void ProduceReferenceAssemblyIsFalse()
-        {
-            ProjectCreator.Templates.NoTargetsProject(
-                    path: GetTempFileWithExtension(".csproj"))
-                .Property("ProduceReferenceAssembly", "true")
-                .Save()
-                .TryGetPropertyValue("IncludeBuildOutput", out string produceReferenceAssembly);
-
-            produceReferenceAssembly.ShouldBe("false");
-        }
-
         [Theory]
         [InlineData(".csproj")]
         [InlineData(".proj")]
@@ -215,6 +156,24 @@ namespace Microsoft.Build.NoTargets.UnitTests
             project3.TryBuild(out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
+        }
+
+        [Theory]
+        [InlineData("DisableImplicitFrameworkReferences", "true")]
+        [InlineData("EnableDefaultCompileItems", "false")]
+        [InlineData("EnableDefaultEmbeddedResourceItems", "false")]
+        [InlineData("GenerateAssemblyInfo", "false")]
+        [InlineData("GenerateMSBuildEditorConfigFile", "false")]
+        [InlineData("IncludeBuildOutput", "false")]
+        [InlineData("ProduceReferenceAssembly", "false")]
+        public void PropertiesHaveExpectedValues(string propertyName, string expectedValue)
+        {
+            ProjectCreator.Templates.NoTargetsProject(
+                path: GetTempFileWithExtension(".csproj"))
+                .Save()
+                .TryGetPropertyValue(propertyName, out string actualValue);
+
+            actualValue.ShouldBe(expectedValue, StringComparer.OrdinalIgnoreCase, customMessage: $"Property {propertyName} should have a value of \"{expectedValue}\" but its value was \"{actualValue}\"");
         }
 
         [Theory]

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -39,6 +39,12 @@
 
     <!-- Don't generate a deps file -->
     <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">false</GenerateDependencyFile>
+
+    <!-- Don't generate assembly info -->
+    <GenerateAssemblyInfo Condition="'$(GenerateAssemblyInfo)' == ''">false</GenerateAssemblyInfo>
+
+    <!-- Don't generate editor config file -->
+    <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">false</GenerateMSBuildEditorConfigFile>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">

--- a/src/NoTargets/version.json
+++ b/src/NoTargets/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "3.1"
+  "version": "3.2"
 }

--- a/src/Shared/MSBuildSdkTestBase.cs
+++ b/src/Shared/MSBuildSdkTestBase.cs
@@ -13,27 +13,10 @@ namespace Microsoft.Build.UnitTests.Common
 {
     public abstract class MSBuildSdkTestBase : MSBuildTestBase, IDisposable
     {
-        private static readonly string[] EnvironmentVariablesToRemove =
-        {
-            "MSBuildSdksPath",
-            "MSBuildExtensionsPath",
-        };
-
-        private readonly string _currentDirectoryBackup;
-        private readonly Dictionary<string, string> _environmentVariableBackup = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private readonly string _testRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
 
         public MSBuildSdkTestBase()
         {
-            File.WriteAllText(
-                Path.Combine(TestRootPath, "global.json"),
-                @"{
-   ""sdk"": {
-    ""version"": ""5.0.100"",
-    ""rollForward"": ""latestMinor""
-  },
-}");
-
             File.WriteAllText(
                 Path.Combine(TestRootPath, "NuGet.config"),
                 @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -44,18 +27,7 @@ namespace Microsoft.Build.UnitTests.Common
   </packageSources>
 </configuration>");
 
-            // Save the current directory to restore it later
-            _currentDirectoryBackup = Environment.CurrentDirectory;
-
             Environment.CurrentDirectory = TestRootPath;
-
-            // Backup and remove environment variables
-            foreach (string environmentVariableName in EnvironmentVariablesToRemove)
-            {
-                _environmentVariableBackup[environmentVariableName] = Environment.GetEnvironmentVariable(environmentVariableName);
-
-                Environment.SetEnvironmentVariable(environmentVariableName, null);
-            }
         }
 
         public string TestRootPath
@@ -91,24 +63,6 @@ namespace Microsoft.Build.UnitTests.Common
         {
             if (disposing)
             {
-                // Restore environment variables
-                foreach (var environmentVariable in _environmentVariableBackup)
-                {
-                    Environment.SetEnvironmentVariable(environmentVariable.Key, environmentVariable.Value);
-                }
-
-                if (Directory.Exists(_currentDirectoryBackup))
-                {
-                    try
-                    {
-                        Environment.CurrentDirectory = _currentDirectoryBackup;
-                    }
-                    catch (Exception)
-                    {
-                        // Ignored
-                    }
-                }
-
                 if (Directory.Exists(TestRootPath))
                 {
                     try


### PR DESCRIPTION
When these properties are enabled, files are generated at build time that are not necessary for NoTargets.

Fixes #278