### PR TITLE
Clean up logging from NoTargets projects

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -166,6 +166,7 @@ namespace Microsoft.Build.NoTargets.UnitTests
         [InlineData("GenerateMSBuildEditorConfigFile", "false")]
         [InlineData("IncludeBuildOutput", "false")]
         [InlineData("ProduceReferenceAssembly", "false")]
+        [InlineData("SkipCopyBuildProduct", "true")]
         public void PropertiesHaveExpectedValues(string propertyName, string expectedValue)
         {
             ProjectCreator.Templates.NoTargetsProject(

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -47,7 +47,7 @@
     <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">false</GenerateMSBuildEditorConfigFile>
     
     <!-- Don't log the high priority message mentioning this project's name (or copy the product we didn't build). -->
-    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
+    <SkipCopyBuildProduct Condition="'$(SkipCopyBuildProduct)' == ''">true</SkipCopyBuildProduct>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -45,6 +45,9 @@
 
     <!-- Don't generate editor config file -->
     <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">false</GenerateMSBuildEditorConfigFile>
+    
+    <!-- Don't log the high priority message mentioning this project's name (or copy the product we didn't build). -->
+    <SkipCopyBuildProduct>true</SkipCopyBuildProduct>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">


### PR DESCRIPTION
A NoTargets project will still log (with high importance) something like:

> MyProject ->

Leaving a blank where the primary output would typically go. This looks weird. So this change removes that from being logged. It also disables (because it's the same property that controls it) copying of the primary output that we didn't build.