### PR TITLE
Log an error if imported in Directory.Build.props

### DIFF
--- a/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
+++ b/src/CentralPackageVersions.UnitTests/CentralPackageVersionsTests.cs
@@ -236,6 +236,37 @@ namespace Microsoft.Build.CentralPackageVersions.UnitTests
             enableCentralPackageVersions.ShouldBe("false");
         }
 
+        [Fact]
+        public void LogErrorIfImportedInDirectoryBuildProps()
+        {
+            ProjectCreator.Create()
+                .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.props"))
+                .Import(Path.Combine(ThisAssemblyDirectory, @"Sdk\Sdk.targets"))
+                .Save(GetTempFile("Directory.Build.props"));
+
+            ProjectCreator.Create()
+                .Save(GetTempFile("Directory.Build.targets"));
+
+            ProjectCreator.Templates
+                .PackagesProps(
+                    path: GetTempFile("Packages.props"),
+                    packageReferences: new Dictionary<string, string>
+                    {
+                        ["Foo"] = "1.2.3",
+                    })
+                .Save();
+
+            ProjectCreator.Templates
+                .SdkCsproj(projectCreator: creator => creator
+                    .ItemPackageReference("Foo"))
+                .Save(GetTempFile("Test.csproj"))
+                .TryBuild("CheckPackageReferences", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeFalse(buildOutput.GetConsoleLog());
+
+            buildOutput.Errors.ShouldBe(new[] { "Microsoft.Build.CentralPackageVersions was not imported in Directory.Build.targets.  See https://github.com/microsoft/MSBuildSdks/tree/main/src/CentralPackageVersions for more information on how to include this SDK." }, buildOutput.GetConsoleLog());
+        }
+
         [Theory]
         [InlineData(".csproj")]
         [InlineData(".fsproj")]

--- a/src/CentralPackageVersions/Sdk/Sdk.props
+++ b/src/CentralPackageVersions/Sdk/Sdk.props
@@ -12,7 +12,5 @@
     <UsingMicrosoftCentralPackageVersionsSdk>true</UsingMicrosoftCentralPackageVersionsSdk>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' And Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') "/>
-
   <Import Project="$(CustomAfterCentralPackageVersionsProps)" Condition=" '$(CustomAfterCentralPackageVersionsProps)' != '' And Exists('$(CustomAfterCentralPackageVersionsProps)') " />
 </Project>

--- a/src/CentralPackageVersions/Sdk/Sdk.targets
+++ b/src/CentralPackageVersions/Sdk/Sdk.targets
@@ -14,6 +14,10 @@
 
   <PropertyGroup Condition=" '$(EnableCentralPackageVersions)' != 'false' ">
     <!--
+      Keep track if this file was imported before Directory.Build.targets
+    -->
+    <_WasMicrosoftCentralPackageVersionsSdkImportedInDirectoryBuildTargets Condition="'$(_WasMicrosoftCentralPackageVersionsSdkImportedInDirectoryBuildTargets)' == '' And '$(DirectoryBuildTargetsPath)' == ''">false</_WasMicrosoftCentralPackageVersionsSdkImportedInDirectoryBuildTargets>
+    <!--
       Walk up the directory tree looking for a Packages.props, unless a user has already specified a path.
     -->
     <CentralPackagesFile Condition=" '$(CentralPackagesFile)' == '' ">$([MSBuild]::GetPathOfFileAbove('Packages.props', $(MSBuildProjectDirectory)))</CentralPackagesFile>
@@ -151,7 +155,13 @@
       <_DuplicateGlobalPackageReference Include="@(_OriginalPackageReference)"
                                         Condition=" '@(GlobalPackageReference)' == '@(_OriginalPackageReference)' and '%(Identity)' != '' " />
     </ItemGroup>
-
+    
+    <!--
+      Log an error if this was imported before Directory.Build.targets
+    -->
+    <Error Text="Microsoft.Build.CentralPackageVersions was not imported in Directory.Build.targets.  See https://github.com/microsoft/MSBuildSdks/tree/main/src/CentralPackageVersions for more information on how to include this SDK."
+           Condition="'$(_WasMicrosoftCentralPackageVersionsSdkImportedInDirectoryBuildTargets)' == 'false'"
+           File="$(MSBuildProjectFullPath)" />
     <!--
       Log an error if there are any duplicate <PackageReference /> items where a <GlobalPackageReference /> is already defined.
     -->


### PR DESCRIPTION
Since the MSBuild Update gesture is used, Microsoft.Build.CentralPackageVersions must be included in Directory.Build.targets not Directory.Build.props.  This change logs an error so that users will know when they've made this mistake.

Fixes #179