### PR TITLE
Override GetTargetPath in Traversal SDK

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -235,6 +235,11 @@
              StopOnFirstFailure="$(StopOnFirstFailure)"
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(PublishContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
+  
+  <!--
+    Traversal projects do not build an assembly so dependent projects shouldn't get a path to the target.  Override the GetTargetPath to do nothing.
+  -->
+  <Target Name="GetTargetPath" />
 
   <!--
     Traversal projects do not build anything and should not check for invalid configuration/platform.


### PR DESCRIPTION
There are use-cases where you want to reference a Traversal SDK project, i.e. when you want to receive its P2P via the `IncludeTransitiveProjectReferences` feature. In such cases msbuild prints out an error when the tree is built with the `--no-dependencies` switch (or I guess when building inside VS) as that will trigger an MSBuild Exec task which calls into the `GetTargetsPath` target which currently either doesn't exist (?) for Traversal projects or returns a TargetPath instead of returning nothing. Hence adding this here to avoid the error that is being printed.

cc @jeffkl