### PR TITLE
Traversal: Have GetTargetPath return collected build outputs

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -8,7 +8,7 @@
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Update="Microsoft.Win32.Registry" Version="4.7.0" />
-    <PackageReference Update="MSBuild.ProjectCreation" Version="7.0.4-preview" />
+    <PackageReference Update="MSBuild.ProjectCreation" Version="7.0.7-preview" />
     <PackageReference Update="Shouldly" Version="4.0.3" />
     <PackageReference Update="xunit" Version="2.4.1" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.3" />

--- a/src/Traversal.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/Traversal.UnitTests/CustomProjectCreatorTemplates.cs
@@ -13,6 +13,21 @@ namespace Microsoft.Build.Traversal.UnitTests
     {
         private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(CustomProjectCreatorTemplates).Assembly.Location);
 
+        public static ProjectCreator ProjectWithBuildOutput(
+            this ProjectCreatorTemplates templates,
+            string target,
+            ProjectCollection projectCollection = null,
+            Action<ProjectCreator> customAction = null)
+        {
+            return ProjectCreator.Templates.SdkCsproj(
+                    sdk: String.Empty,
+                    projectCreator: customAction,
+                    projectCollection: projectCollection)
+                .Target(target, returns: "@(CollectedBuildOutput)")
+                    .TargetItemInclude("CollectedBuildOutput", Path.Combine("bin", "$(MSBuildThisFileName).dll"))
+                .Target("Clean");
+        }
+
         public static ProjectCreator TraversalProject(
             this ProjectCreatorTemplates templates,
             string[] projectReferences = null,

--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -19,57 +19,34 @@ namespace Microsoft.Build.Traversal.UnitTests
     public class TraversalTests : MSBuildSdkTestBase
     {
         [Theory]
-        [InlineData(null)]
         [InlineData("Build")]
-        [InlineData("Rebuild")]
+        [InlineData("GetTargetPath")]
         public void CollectsProjectReferenceBuildTargetOutputs(string target)
         {
-            string[] projects = new[]
-            {
-                GetSkeletonCSProjWithTargetOutputs(@"A\A"),
-                GetSkeletonCSProjWithTargetOutputs(@"B\B"),
-            }.Select(i => i.FullPath).ToArray();
-
-            var subTraversalProject = ProjectCreator
-                .Templates
-                .TraversalProject(projects, path: GetTempFile(@"dirs\dirs.proj"))
-                .Save();
-
-            ProjectCreator
-                .Create(path: GetTempFile("root.proj"))
-                .Target("BuildTraversalProject")
-                .Task(
-                    "MSBuild",
-                    parameters: new Dictionary<string, string>
+            ProjectCreator traversalProject = ProjectCreator.Templates.TraversalProject(
+                    projectReferences: new string[]
                     {
-                        ["Projects"] = subTraversalProject.FullPath,
-                        ["Targets"] = "Restore",
-                        ["Properties"] = $"MSBuildRestoreSessionId={Guid.NewGuid():N}",
+                        ProjectCreator.Templates.ProjectWithBuildOutput(target)
+                            .Save(GetTempFile(Path.Combine("A", "A.csproj"))),
+                        ProjectCreator.Templates.ProjectWithBuildOutput(target)
+                            .Save(GetTempFile(Path.Combine("B", "B.csproj"))),
                     })
-                .Task(
-                    "MSBuild",
-                    parameters: new Dictionary<string, string>
-                    {
-                        ["Projects"] = subTraversalProject.FullPath,
-                        ["Targets"] = target,
-                    })
-                .TaskOutputItem("TargetOutputs", "CollectedOutputs")
-                .TaskMessage("%(CollectedOutputs.Identity)", MessageImportance.High)
-                .Save()
-                .TryBuild("BuildTraversalProject", out bool _, out BuildOutput buildOutput);
+                .Property("SkipResolvePackageAssets", bool.TrueString)
+                .Target("ResolvePackageAssets")
+                .Save(GetTempFile("dirs.proj"))
+                .TryBuild(target, out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
 
-            buildOutput.Messages.High.ShouldContain("A.dll", buildOutput.GetConsoleLog());
-            buildOutput.Messages.High.ShouldContain("B.dll", buildOutput.GetConsoleLog());
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
 
-            ProjectCreator GetSkeletonCSProjWithTargetOutputs(string projectName)
-            {
-                return ProjectCreator.Templates.SdkCsproj(path: GetTempFile($"{projectName}.csproj"), sdk: string.Empty)
-                                    .Target("Build", returns: "@(TestReturnItem)")
-                                    .TargetItemGroup()
-                                    .TargetItemInclude("TestReturnItem", "$(MSBuildThisFileName).dll")
-                                    .Target("Clean")
-                                    .Save();
-            }
+            targetOutputs.ShouldContainKey(target, buildOutput.GetConsoleLog());
+
+            targetOutputs[target].Items.Select(i => i.ItemSpec).ShouldBe(
+                new[]
+                {
+                    Path.Combine("bin", "A.dll"),
+                    Path.Combine("bin", "B.dll"),
+                },
+                buildOutput.GetConsoleLog());
         }
 
         [Fact]

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -95,6 +95,10 @@
 
     <PublishDependsOn Condition="'$(NoBuild)' == 'true'">
     </PublishDependsOn>
+    
+    <GetTargetPathDependsOn>
+      ResolveP2PReferences;
+    </GetTargetPathDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TraversalTranslateProjectFileItems)' != 'false' ">
@@ -236,10 +240,23 @@
              ContinueOnError="$([MSBuild]::ValueOrDefault('$(PublishContinueOnError)', '$(ContinueOnError)'))" />
   </Target>
   
-  <!--
-    Traversal projects do not build an assembly so dependent projects shouldn't get a path to the target.  Override the GetTargetPath to do nothing.
-  -->
-  <Target Name="GetTargetPath" />
+  <Target Name="GetTargetPath"
+          DependsOnTargets="$(GetTargetPathDependsOn)"
+          Returns="@(CollectedBuildOutput)">
+    <MSBuild Projects="@(ProjectReference)"
+             Condition="'%(ProjectReference.Build)' != 'false'"
+             Targets="GetTargetPath"
+             BuildInParallel="$([MSBuild]::ValueOrDefault('%(ProjectReference.BuildInParallel)', '$(BuildInParallel)'))"
+             SkipNonexistentProjects="$(SkipNonexistentProjects)"
+             SkipNonexistentTargets="$(SkipNonexistentTargets)"
+             StopOnFirstFailure="$(StopOnFirstFailure)"
+             Properties="%(ProjectReference.SetConfiguration); %(ProjectReference.SetPlatform); %(ProjectReference.SetTargetFramework)"
+             ContinueOnError="$(ContinueOnError)">
+      <Output TaskParameter="TargetOutputs" ItemName="CollectedBuildOutput" />
+    </MSBuild>
+  </Target>
+
+  <Target Name="GetTargetPathWithTargetPlatformMoniker" />
 
   <!--
     Traversal projects do not build anything and should not check for invalid configuration/platform.

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -96,9 +96,7 @@
     <PublishDependsOn Condition="'$(NoBuild)' == 'true'">
     </PublishDependsOn>
     
-    <GetTargetPathDependsOn>
-      ResolveP2PReferences;
-    </GetTargetPathDependsOn>
+    <GetTargetPathDependsOn></GetTargetPathDependsOn>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TraversalTranslateProjectFileItems)' != 'false' ">


### PR DESCRIPTION
https://github.com/microsoft/MSBuildSdks/commit/1c02e77c5d96c50b803e348b6c3444b578d3dee0 I made the GetTargetPath target for traversal projects return nothing. This is actually wrong as msbuild projects are expected to return the same data in the Build and the GetTargetPath target.
If those two targets aren't in sync, a behavior difference is observable when a traversal project is P2Pd and the dependent project reads from the `CollectedBuildOutput` (which is returned by the `ResolveProjectReferences` target). If the `BuildProjectReferences=true` flag is passed in, the output in the ResolveP2P is currently empty vs. not empty during a normal build without the flag set.

I tested this locally and am also submitting a PR into dotnet/runtime right now which depends on this behavior (currently via the AfterTargets extension point of the Traversal project). Would be great if we could get this into main here so that I can remove the custom implementation in dotnet/runtime.

cc @jeffkl