### PR TITLE
Pass in properties for inner build targets

### DIFF
--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -158,6 +158,7 @@
                                 $([MSBuild]::ValueOrDefault('$(CleanInParallel)', '$(BuildInParallel)'))
                                 ))
                                ))"
+             Properties="%(ProjectReference.SetConfiguration); %(ProjectReference.SetPlatform); %(ProjectReference.SetTargetFramework)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
              StopOnFirstFailure="$(StopOnFirstFailure)"
@@ -180,6 +181,7 @@
                                 $([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))
                                 ))
                                ))"
+             Properties="%(ProjectReference.SetConfiguration); %(ProjectReference.SetPlatform); %(ProjectReference.SetTargetFramework)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
              StopOnFirstFailure="$(StopOnFirstFailure)"
@@ -197,6 +199,7 @@
                                 $([MSBuild]::ValueOrDefault('$(TestInParallel)', '$(BuildInParallel)'))
                                 ))
                                ))"
+             Properties="%(ProjectReference.SetConfiguration); %(ProjectReference.SetPlatform); %(ProjectReference.SetTargetFramework)"
              SkipNonexistentProjects="$(SkipNonexistentProjects)"
              SkipNonexistentTargets="$(SkipNonexistentTargets)"
              StopOnFirstFailure="$(StopOnFirstFailure)"


### PR DESCRIPTION
As the `Clean`, `Test` and `VSTest` targets exist in inner builds, we should pass in properties that `ResolveProjectReferences` in Common.targets passes in as well. The Build and GetTargetPath targets already do so but the above listed targets don't which causes unnecessary clean and test invocations when a specific target framework is set.

cc @jeffkl @ericstj