### PR TITLE
Set properties to disable symbols and Visual Studio fast up-to-date check

### DIFF
--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -165,6 +165,9 @@ namespace Microsoft.Build.NoTargets.UnitTests
         [InlineData("SkipCopyBuildProduct", "true")]
         [InlineData("AutomaticallyUseReferenceAssemblyPackages", "false")]
         [InlineData("NoCompilerStandardLib", "false")]
+        [InlineData("DebugType", "None")]
+        [InlineData("DebugSymbols", "false")]
+        [InlineData("DisableFastUpToDateCheck", "true")]
         public void PropertiesHaveExpectedValues(string propertyName, string expectedValue)
         {
             ProjectCreator.Templates.NoTargetsProject(

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -52,6 +52,13 @@
     <!-- Don't automatically reference assembly packages since NoTargets don't need reference assemblies -->
     <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
     <NoCompilerStandardLib Condition="'$(NoCompilerStandardLib)' == ''">false</NoCompilerStandardLib>
+    
+    <!-- Indicate no symbols will be generated -->
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    
+    <!-- Disable Visual Studio's Fast Up-to-date Check and rely on MSBuild to determine -->
+    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -54,11 +54,11 @@
     <NoCompilerStandardLib Condition="'$(NoCompilerStandardLib)' == ''">false</NoCompilerStandardLib>
     
     <!-- Indicate no symbols will be generated -->
-    <DebugType>None</DebugType>
-    <DebugSymbols>false</DebugSymbols>
+    <DebugType Condition="'$(DebugType)' == ''">None</DebugType>
+    <DebugSymbols Condition="'$(DebugSymbols)' == ''">false</DebugSymbols>
     
     <!-- Disable Visual Studio's Fast Up-to-date Check and rely on MSBuild to determine -->
-    <DisableFastUpToDateCheck>True</DisableFastUpToDateCheck>
+    <DisableFastUpToDateCheck Condition="'$(DisableFastUpToDateCheck )' == ''">true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">


### PR DESCRIPTION
Updates to NoTargets SDK props:
*  Set properties to indicate NoTargets projects don't generate symbols
*  Disable VS Fast Up-to-date Check for NoTargets SDK projects and rely on MSBuild

Documentation regarding Visual Studio's Up-to-date Check:
https://github.com/dotnet/project-system/blob/main/docs/up-to-date-check.md#disabling-the-up-to-date-check