### PR TITLE
Stop testing against net5.0

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -3,7 +3,6 @@
     <MicrosoftBuildPackageVersion>17.0.0</MicrosoftBuildPackageVersion>
     <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'netcoreapp3.1'">16.9.0</MicrosoftBuildPackageVersion>
     <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net46'">15.9.20</MicrosoftBuildPackageVersion>
-    <MicrosoftBuildPackageVersion Condition="'$(TargetFramework)' == 'net5.0'">16.11.0</MicrosoftBuildPackageVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Update="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,6 @@ variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
   DotNet3Version: '3.x'
-  DotNet5Version: '5.x'
   DotNet6Version: '6.x'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Test'
@@ -42,11 +41,6 @@ jobs:
       version: '$(DotNet3Version)'
 
   - task: UseDotNet@2
-    displayName: 'Install .NET $(DotNet5Version)'
-    inputs:
-      version: '$(DotNet5Version)'
-
-  - task: UseDotNet@2
     displayName: 'Install .NET $(DotNet6Version)'
     inputs:
       version: '$(DotNet6Version)'
@@ -74,14 +68,6 @@ jobs:
     condition: succeededOrFailed()
 
   - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests (.NET 5.0)'
-    inputs:
-      command: 'test'
-      arguments: '--no-restore --no-build --framework net5.0 /noautorsp'
-      testRunTitle: 'Windows .NET 5.0'
-    condition: succeededOrFailed()
-
-  - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 6.0)'
     inputs:
       command: 'test'
@@ -103,11 +89,6 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: 'Install .NET $(DotNet5Version)'
-    inputs:
-      version: '$(DotNet5Version)'
-
-  - task: UseDotNet@2
     displayName: 'Install .NET $(DotNet6Version)'
     inputs:
       version: '$(DotNet6Version)'
@@ -117,14 +98,6 @@ jobs:
     inputs:
       command: 'build'
       arguments: '$(MSBuildArgs)'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests (.NET 5.0)'
-    inputs:
-      command: 'test'
-      arguments: '--no-restore --no-build --framework net5.0 /noautorsp'
-      testRunTitle: 'Linux .NET 5.0'
-    condition: succeededOrFailed()
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 6.0)'
@@ -148,11 +121,6 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: 'Install .NET $(DotNet5Version)'
-    inputs:
-      version: '$(DotNet5Version)'
-
-  - task: UseDotNet@2
     displayName: 'Install .NET $(DotNet6Version)'
     inputs:
       version: '$(DotNet6Version)'
@@ -162,14 +130,6 @@ jobs:
     inputs:
       command: 'build'
       arguments: '$(MSBuildArgs)'
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests (.NET 5.0)'
-    inputs:
-      command: 'test'
-      arguments: '--no-restore --no-build --framework net5.0 /noautorsp'
-      testRunTitle: 'MacOS .NET 5.0'
-    condition: succeededOrFailed()
 
   - task: DotNetCoreCLI@2
     displayName: 'Run Unit Tests (.NET 6.0)'

--- a/samples/CentralPackageVersions/src/ClassLibrary/ClassLibrary.csproj
+++ b/samples/CentralPackageVersions/src/ClassLibrary/ClassLibrary.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" />

--- a/samples/NoTargets/SampleNoTargets/SampleNoTargets.csproj
+++ b/samples/NoTargets/SampleNoTargets/SampleNoTargets.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.Build.NoTargets/3.3.0">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <Target Name="CustomAction" AfterTargets="Build">

--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
+++ b/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
+++ b/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
+++ b/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
.NET 5.0 is out of support soon so just stop running tests against it.  The rest of the actual production logic supports any framework.