### PR TITLE
Disable CentralPackageVersions if using NuGet's built in central package management

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -3,6 +3,7 @@
 
   <PropertyGroup>
     <MicroBuild_NuPkgSigningEnabled Condition="'$(SignType)' == 'Test'">false</MicroBuild_NuPkgSigningEnabled>
+    <NoWarn Condition="'$(IsTestProject)' == 'true'">$(NoWarn);SA1600</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SignType)' == 'Test'">

--- a/src/CentralPackageVersions/Sdk/Sdk.props
+++ b/src/CentralPackageVersions/Sdk/Sdk.props
@@ -5,14 +5,21 @@
   Licensed under the MIT license.
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(CustomBeforeCentralPackageVersionsProps)" Condition=" '$(CustomBeforeCentralPackageVersionsProps)' != '' And Exists('$(CustomBeforeCentralPackageVersionsProps)') " />
-
   <PropertyGroup>
+    <!--
+      Disable Microsoft.Build.CentralPackageVersions if NuGet's built in central package management is in use
+    -->
+    <EnableCentralPackageVersions Condition="'$(ManagePackageVersionsCentrally)' == 'true'">false</EnableCentralPackageVersions>
+  </PropertyGroup>
+  
+  <Import Project="$(CustomBeforeCentralPackageVersionsProps)" Condition="'$(EnableCentralPackageVersions)' != 'false' And '$(CustomBeforeCentralPackageVersionsProps)' != '' And Exists('$(CustomBeforeCentralPackageVersionsProps)')" />
+
+  <PropertyGroup Condition="'$(EnableCentralPackageVersions)' != 'false'">
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
     <UsingMicrosoftCentralPackageVersionsSdk>true</UsingMicrosoftCentralPackageVersionsSdk>
   </PropertyGroup>
 
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' And Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props') "/>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="'$(EnableCentralPackageVersions)' != 'false' And '$(MicrosoftCommonPropsHasBeenImported)' != 'true' And Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
 
-  <Import Project="$(CustomAfterCentralPackageVersionsProps)" Condition=" '$(CustomAfterCentralPackageVersionsProps)' != '' And Exists('$(CustomAfterCentralPackageVersionsProps)') " />
+  <Import Project="$(CustomAfterCentralPackageVersionsProps)" Condition="'$(EnableCentralPackageVersions)' != 'false' And '$(CustomAfterCentralPackageVersionsProps)' != '' And Exists('$(CustomAfterCentralPackageVersionsProps)')" />
 </Project>

--- a/src/CentralPackageVersions/Sdk/Sdk.targets
+++ b/src/CentralPackageVersions/Sdk/Sdk.targets
@@ -6,6 +6,13 @@
 -->
 <Project InitialTargets="CheckPackageReferences" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <PropertyGroup>
+    <!--
+      Disable Microsoft.Build.CentralPackageVersions if NuGet's built in central package management is in use
+    -->
+    <EnableCentralPackageVersions Condition="'$(ManagePackageVersionsCentrally)' == 'true'">false</EnableCentralPackageVersions>
+  </PropertyGroup>
+
   <!--
     Import a user extension if specified.
   -->

--- a/src/CentralPackageVersions/version.json
+++ b/src/CentralPackageVersions/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "2.1"
+  "version": "2.2"
 }


### PR DESCRIPTION
- [x] Fixes https://github.com/microsoft/MSBuildSdks/issues/350