### PR TITLE
Set DebugType and DebugSymbols after SDK import

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,7 +6,7 @@ variables:
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
   DotNet3Version: '3.x'
-  DotNet6Version: '6.x'
+  DotNet6Version: '6.0.203'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Test'
 

--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -177,7 +177,7 @@ namespace Microsoft.Build.NoTargets.UnitTests
         [InlineData("IncludeBuildOutput", null, "false")]
         [InlineData("NoCompilerStandardLib", "true", "true")]
         [InlineData("NoCompilerStandardLib", null, "false")]
-        [InlineData("ProduceReferenceAssembly", "true", "true")]
+        [InlineData("ProduceReferenceAssembly", "true", "false")]
         [InlineData("ProduceReferenceAssembly", null, "false")]
         [InlineData("SkipCopyBuildProduct", "false", "false")]
         [InlineData("SkipCopyBuildProduct", null, "true")]

--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -155,23 +155,37 @@ namespace Microsoft.Build.NoTargets.UnitTests
         }
 
         [Theory]
-        [InlineData("DisableImplicitFrameworkReferences", "true")]
-        [InlineData("EnableDefaultCompileItems", "false")]
-        [InlineData("EnableDefaultEmbeddedResourceItems", "false")]
-        [InlineData("GenerateAssemblyInfo", "false")]
-        [InlineData("GenerateMSBuildEditorConfigFile", "false")]
-        [InlineData("IncludeBuildOutput", "false")]
-        [InlineData("ProduceReferenceAssembly", "false")]
-        [InlineData("SkipCopyBuildProduct", "true")]
-        [InlineData("AutomaticallyUseReferenceAssemblyPackages", "false")]
-        [InlineData("NoCompilerStandardLib", "false")]
-        [InlineData("DebugType", "None")]
-        [InlineData("DebugSymbols", "false")]
-        [InlineData("DisableFastUpToDateCheck", "true")]
-        public void PropertiesHaveExpectedValues(string propertyName, string expectedValue)
+        [InlineData("AutomaticallyUseReferenceAssemblyPackages", "true", "true")]
+        [InlineData("AutomaticallyUseReferenceAssemblyPackages", null, "false")]
+        [InlineData("DebugSymbols", "true", "false")]
+        [InlineData("DebugSymbols", null, "false")]
+        [InlineData("DebugType", "Full", "None")]
+        [InlineData("DebugType", null, "None")]
+        [InlineData("DisableFastUpToDateCheck", "false", "false")]
+        [InlineData("DisableFastUpToDateCheck", null, "true")]
+        [InlineData("DisableImplicitFrameworkReferences", "false", "false")]
+        [InlineData("DisableImplicitFrameworkReferences", null, "true")]
+        [InlineData("EnableDefaultCompileItems", "true", "true")]
+        [InlineData("EnableDefaultCompileItems", null, "false")]
+        [InlineData("EnableDefaultEmbeddedResourceItems", "true", "true")]
+        [InlineData("EnableDefaultEmbeddedResourceItems", null, "false")]
+        [InlineData("GenerateAssemblyInfo", "true", "true")]
+        [InlineData("GenerateAssemblyInfo", null, "false")]
+        [InlineData("GenerateMSBuildEditorConfigFile", "true", "true")]
+        [InlineData("GenerateMSBuildEditorConfigFile", null, "false")]
+        [InlineData("IncludeBuildOutput", "true", "true")]
+        [InlineData("IncludeBuildOutput", null, "false")]
+        [InlineData("NoCompilerStandardLib", "true", "true")]
+        [InlineData("NoCompilerStandardLib", null, "false")]
+        [InlineData("ProduceReferenceAssembly", "true", "true")]
+        [InlineData("ProduceReferenceAssembly", null, "false")]
+        [InlineData("SkipCopyBuildProduct", "false", "false")]
+        [InlineData("SkipCopyBuildProduct", null, "true")]
+        public void PropertiesHaveExpectedValues(string propertyName, string value, string expectedValue)
         {
             ProjectCreator.Templates.NoTargetsProject(
                 path: GetTempFileWithExtension(".csproj"))
+                .Property(propertyName, value)
                 .Save()
                 .TryGetPropertyValue(propertyName, out string actualValue);
 

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -72,12 +72,6 @@
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>
 
-  <!-- Indicate no symbols will be generated. Setting this in .props allows projects to redefine if needed. -->
-  <PropertyGroup>
-    <DebugType>None</DebugType>
-    <DebugSymbols>false</DebugSymbols>
-  </PropertyGroup>
-
   <Import Project="$(CustomAfterNoTargetsProps)" Condition=" '$(CustomAfterNoTargetsProps)' != '' And Exists('$(CustomAfterNoTargetsProps)') " />
 
   <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if needed -->

--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -53,10 +53,6 @@
     <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
     <NoCompilerStandardLib Condition="'$(NoCompilerStandardLib)' == ''">false</NoCompilerStandardLib>
     
-    <!-- Indicate no symbols will be generated -->
-    <DebugType Condition="'$(DebugType)' == ''">None</DebugType>
-    <DebugSymbols Condition="'$(DebugSymbols)' == ''">false</DebugSymbols>
-    
     <!-- Disable Visual Studio's Fast Up-to-date Check and rely on MSBuild to determine -->
     <DisableFastUpToDateCheck Condition="'$(DisableFastUpToDateCheck)' == ''">true</DisableFastUpToDateCheck>
   </PropertyGroup>
@@ -75,6 +71,12 @@
   <Target Name="CreateManifestResourceNames" />
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>
+
+  <!-- Indicate no symbols will be generated. Setting this in .props allows projects to redefine if needed. -->
+  <PropertyGroup>
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+  </PropertyGroup>
 
   <Import Project="$(CustomAfterNoTargetsProps)" Condition=" '$(CustomAfterNoTargetsProps)' != '' And Exists('$(CustomAfterNoTargetsProps)') " />
 

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -29,25 +29,7 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
 
   <PropertyGroup>
-    <!-- Don't emit a reference assembly -->
-    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
-  </PropertyGroup>
-
-  <ItemGroup>
-    <IntermediateAssembly Remove="@(IntermediateAssembly)" />
-    <IntermediateRefAssembly Remove="@(IntermediateRefAssembly)" />
-  </ItemGroup>
-
-  <!-- Clear output group items which are read by the IDE and NuGet. -->
-  <ItemGroup>
-    <BuiltProjectOutputGroupKeyOutput Remove="@(BuiltProjectOutputGroupKeyOutput)" />
-    <DebugSymbolsProjectOutputGroupOutput Remove="@(DebugSymbolsProjectOutputGroupOutput)" />
-  </ItemGroup>
-
-  <PropertyGroup>
-    <!--
-      This property must be overridden to remove a few targets that compile assemblies
-    -->
+    <!-- This property must be overridden to remove a few targets that compile assemblies -->
     <CoreBuildDependsOn>
       BuildOnlySettings;
       PrepareForBuild;
@@ -59,7 +41,22 @@
       IncrementalClean;
       PostBuildEvent
     </CoreBuildDependsOn>
+    
+    <!-- Disable symbol generation -->
+    <DebugType>None</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    
+    <!-- Don't emit a reference assembly -->
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
   </PropertyGroup>
+
+  <!-- Clear output group items which are read by the IDE and NuGet. -->
+  <ItemGroup>
+    <BuiltProjectOutputGroupKeyOutput Remove="@(BuiltProjectOutputGroupKeyOutput)" />
+    <DebugSymbolsProjectOutputGroupOutput Remove="@(DebugSymbolsProjectOutputGroupOutput)" />
+    <IntermediateAssembly Remove="@(IntermediateAssembly)" />
+    <IntermediateRefAssembly Remove="@(IntermediateRefAssembly)" />
+  </ItemGroup>
 
   <!--
     The CopyFilesToOutputDirectory target is hard coded to depend on ComputeIntermediateSatelliteAssemblies.  NoTargets projects do no generate resource assemblies

--- a/src/NoTargets/version.json
+++ b/src/NoTargets/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "3.4"
+  "version": "3.5"
 }


### PR DESCRIPTION
It's fairly common for repositories to set a default DebugType and/or DebugSymbols setting in their Directory.Build.props file. As an example, Arcade does that which impacts every repository in the .NET stack. The NoTargets SDK should overwrite these default settings (including the Microsoft.NET.Sdk setting) as the project clearly doesn't produce a symbol. Setting in the props file to allow a project to overwrite the setting if it explicitly wants to do so.