### PR TITLE
Add option to disable CopyFilesMarkedCopyLocal target

### DIFF
--- a/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
+++ b/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
@@ -15,7 +15,6 @@
     <ProjectReference Include="..\NoTargets\Microsoft.Build.NoTargets.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\NoTargets\Sdk\Sdk.props" Link="Sdk\Sdk.props" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="..\NoTargets\Sdk\Sdk.targets" Link="Sdk\Sdk.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\NoTargets\Sdk\**\*" Link="Sdk\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -13,12 +13,25 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Xunit;
 
 namespace Microsoft.Build.NoTargets.UnitTests
 {
     public class NoTargetsTests : MSBuildSdkTestBase
     {
+        [Fact]
+        public void CanDisableCopyFilesMarkedCopyLocal()
+        {
+            ProjectCreator.Templates.NoTargetsProject(
+                path: GetTempFileWithExtension(".csproj"))
+                .Property("SkipCopyFilesMarkedCopyLocal", bool.TrueString)
+                .ItemInclude("ReferenceCopyLocalPaths", Assembly.GetExecutingAssembly().Location)
+                .TryBuild("_CopyFilesMarkedCopyLocal", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+        }
+
         [Theory]
         [InlineData("BeforeCompile")]
         [InlineData("AfterCompile")]
@@ -181,6 +194,9 @@ namespace Microsoft.Build.NoTargets.UnitTests
         [InlineData("ProduceReferenceAssembly", null, "false")]
         [InlineData("SkipCopyBuildProduct", "false", "false")]
         [InlineData("SkipCopyBuildProduct", null, "true")]
+        [InlineData("SkipCopyFilesMarkedCopyLocal", "false", "false")]
+        [InlineData("SkipCopyFilesMarkedCopyLocal", "true", "true")]
+        [InlineData("SkipCopyFilesMarkedCopyLocal", null, "")]
         public void PropertiesHaveExpectedValues(string propertyName, string value, string expectedValue)
         {
             ProjectCreator.Templates.NoTargetsProject(

--- a/src/NoTargets/Sdk/DisableCopyFilesMarkedCopyLocal.targets
+++ b/src/NoTargets/Sdk/DisableCopyFilesMarkedCopyLocal.targets
@@ -1,0 +1,4 @@
+<Project>
+  <!-- Disables the _CopyFilesMarkedCopyLocal target by overriding it -->
+  <Target Name="_CopyFilesMarkedCopyLocal" />
+</Project>

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -78,6 +78,9 @@
     The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
   -->
   <Target Name="GetTargetPathWithTargetPlatformMoniker" />
+  
+  <!-- Override CopyFilesMarkedCopyLocal target to not copy references when NoTargetsDoNotReferenceOutputAssemblies is set to false. -->
+  <Target Name="_CopyFilesMarkedCopyLocal" />
 
   <!--
     The GetReferenceAssemblyPaths does not need to run since reference assemblies aren't needed.

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -79,8 +79,8 @@
   -->
   <Target Name="GetTargetPathWithTargetPlatformMoniker" />
   
-  <!-- Override CopyFilesMarkedCopyLocal target to not copy references when NoTargetsDoNotReferenceOutputAssemblies is set to false. -->
-  <Target Name="_CopyFilesMarkedCopyLocal" />
+  <!-- Override CopyFilesToOutputDirectory target to not copy references when NoTargetsDoNotReferenceOutputAssemblies is set to false. -->
+  <Target Name="CopyFilesToOutputDirectory" />
 
   <!--
     The GetReferenceAssemblyPaths does not need to run since reference assemblies aren't needed.

--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -78,9 +78,6 @@
     The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
   -->
   <Target Name="GetTargetPathWithTargetPlatformMoniker" />
-  
-  <!-- Override CopyFilesToOutputDirectory target to not copy references when NoTargetsDoNotReferenceOutputAssemblies is set to false. -->
-  <Target Name="CopyFilesToOutputDirectory" />
 
   <!--
     The GetReferenceAssemblyPaths does not need to run since reference assemblies aren't needed.
@@ -104,4 +101,7 @@
 
   <Target Name="_GenerateCompileInputs" />
   <Target Name="_GenerateCompileDependencyCache" />
+
+  <!-- Disables the _CopyFilesMarkedCopyLocal target to not copy references when SkipCopyFilesMarkedCopyLocal is set to false. -->
+  <Import Project="DisableCopyFilesMarkedCopyLocal.targets" Condition="'$(SkipCopyFilesMarkedCopyLocal)' == 'true'" />
 </Project>


### PR DESCRIPTION
This adds a new property `SkipCopyFilesMarkedCopyLocal` which can be set to `true` to disable the `CopyFilesMarkedCopyLocal` target.

```xml
<PropertyGroup>
  <SkipCopyFilesMarkedCopyLocal>true</SkipCopyFilesMarkedCopyLocal>
</PropertyGroup>
```