### PR TITLE
Include semicolon and comma as valid seperators for DirExclude, FileExclude, and FileMatch

### DIFF
--- a/src/Artifacts/Tasks/RobocopyMetadata.cs
+++ b/src/Artifacts/Tasks/RobocopyMetadata.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Build.Artifacts.Tasks
     internal sealed class RobocopyMetadata
     {
         private static readonly char[] DestinationSplitter = { ';' };
-        private static readonly char[] MultiSplits = { '\t', ' ', '\n', '\r' };
+        private static readonly char[] MultiSplits = { '\t', ' ', '\n', '\r', ';', ',' };
         private static readonly char[] Wildcards = { '?', '*' };
 
         private RobocopyMetadata()


### PR DESCRIPTION
Fixes #402