### PR TITLE
Improve splitting of file include and exclude patterns

### DIFF
--- a/src/Artifacts.UnitTests/ArtifactsTests.cs
+++ b/src/Artifacts.UnitTests/ArtifactsTests.cs
@@ -266,9 +266,9 @@ namespace Microsoft.Build.Artifacts.UnitTests
                 .TryGetPropertyValue("DefaultArtifactsSource", out string _)
                 .TryBuild(out bool result, out BuildOutput buildOutput);
 
-            string consoleLog = buildOutput.GetConsoleLog();
-            result.ShouldBeFalse(consoleLog);
-            Assert.Contains($"Failed to expand the path \"{artifactPaths}", consoleLog);
+            result.ShouldBeFalse(buildOutput.GetConsoleLog());
+
+            buildOutput.Errors.ShouldContain(i => i.Contains($"Failed to expand the path \"{artifactPaths}"), buildOutput.GetConsoleLog());
         }
 
         [Theory]

--- a/src/Artifacts.UnitTests/RobocopyMetadataTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyMetadataTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
         }
 
         [Theory]
-        [MemberData("GetSplitSeperators")]
+        [MemberData(nameof(GetSplitSeperators))]
         public void SplitMetadataTest(string separator)
         {
             string actual = string.Join(

--- a/src/Artifacts.UnitTests/RobocopyMetadataTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyMetadataTests.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Artifacts.Tasks;
+using Shouldly;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+
+namespace Microsoft.Build.Artifacts.UnitTests
+{
+    public class RobocopyMetadataTests
+    {
+        public static IEnumerable<object[]> GetSplitSeperators()
+        {
+            foreach (var item in RobocopyMetadata.MultiSplits)
+            {
+                yield return new[] { item.ToString() };
+            }
+        }
+
+        [Theory]
+        [MemberData("GetSplitSeperators")]
+        public void SplitMetadataTest(string separator)
+        {
+            string actual = string.Join(
+                separator,
+                new[]
+                {
+                    "1",
+                    "22",
+                    "\"333 4444 55555\"",
+                    "666666",
+                    "    ",
+                    "\"7777777,88888888\"",
+                });
+
+            RobocopyMetadata.SplitMetadata(actual)
+                .ToArray()
+                .ShouldBe(new[] { "1", "22", "333 4444 55555", "666666", "7777777,88888888" });
+        }
+    }
+}

--- a/src/Artifacts.UnitTests/RobocopyTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyTests.cs
@@ -40,8 +40,8 @@ namespace Microsoft.Build.Artifacts.UnitTests
                 {
                     new MockTaskItem(source.FullName)
                     {
-                        ["DestinationFolder"] = destination.FullName,
-                        ["FileMatch"] = "*txt",
+                        [RobocopyMetadata.DestinationFolder] = destination.FullName,
+                        [RobocopyMetadata.FileMatch] = "*txt",
                         [nameof(RobocopyMetadata.IsRecursive)] = "false",
                     },
                 },
@@ -91,8 +91,8 @@ namespace Microsoft.Build.Artifacts.UnitTests
                 {
                     new MockTaskItem(source.FullName)
                     {
-                        ["DestinationFolder"] = destination.FullName,
-                        ["FileMatch"] = "*exe *dll *exe.config",
+                        [RobocopyMetadata.DestinationFolder] = destination.FullName,
+                        [RobocopyMetadata.FileMatch] = "*exe *dll *exe.config",
                     },
                 },
                 Sleep = duration => { },

--- a/src/Artifacts/README.md
+++ b/src/Artifacts/README.md
@@ -172,9 +172,9 @@ The `<Artifact />` items specify collections of artifacts to stage.  These items
 | `VerifyExists`  | Enables a check that the file exists before copying | `true` |
 | `AlwaysCopy` | Enables copies even if the destination already exists | `false` |
 | `OnlyNewer`  | Enables copies only if the destnation exist and the source is newer | `false` |
-| `FileMatch` | A list of one or more file filters seperated by a space or semicolon to include.  Wildcards include `*` and `?` | `*`|
-| `FileExclude`   | A list of one or more file filters seperated by a space or semicolon to exclude.  Wildcards include `*` and `?` | |
-| `DirExclude`   | A list of one or more directory filters seperated by a space or semicolon to exclude.  Wildcards include `*` and `?` | |
+| `FileMatch` | A list of one or more quoted file filters seperated by a semicolon, space, or comma to include.  Wildcards include `*` and `?` | `*`|
+| `FileExclude`   | A list of one or more quoted file filters seperated by a semicolon, space, or comma to exclude.  Wildcards include `*` and `?` | |
+| `DirExclude`   | A list of one or more directory quoted filters seperated by a semicolon, space, or comma to exclude.  Wildcards include `*` and `?` | |
 
 **Example**
 

--- a/src/Artifacts/version.json
+++ b/src/Artifacts/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "4.2"
+  "version": "5.0"
 }


### PR DESCRIPTION
Now splits on semicolon, comma, space, and line breaks where each token can also be quoted.