### PR TITLE
Fix import ordering of design-time build targets for NoTargets with .proj extension

### DIFF
--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -24,6 +24,9 @@
   <PropertyGroup>
     <!-- Don't include build output in a package since NoTargets projects don't emit an assembly. -->
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)' == ''">false</IncludeBuildOutput>
+
+    <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
+    <CustomBeforeMicrosoftCommonTargets Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">$(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
@@ -64,10 +67,6 @@
     so the target is replaced with a no-op
   -->
   <Target Name="ComputeIntermediateSatelliteAssemblies" />
-
-  <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
-  <Import Project="$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets" 
-          Condition="'$(DebuggerFlavor)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')" />
 
   <!--
     NoTargets projects do not build an assembly so dependent projects shouldn't get a path to the target.  Override the GetTargetPath to do nothing.

--- a/src/NoTargets/version.json
+++ b/src/NoTargets/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "3.6"
+  "version": "3.7"
 }


### PR DESCRIPTION
Fixes https://github.com/microsoft/MSBuildSdks/issues/407