### PR TITLE
Move CopyOnWrite dlls from lib to build

### DIFF
--- a/Packages.props
+++ b/Packages.props
@@ -15,7 +15,7 @@
     <PackageReference Update="Shouldly" Version="4.1.0" />
     <PackageReference Update="xunit" Version="2.4.2" />
     <PackageReference Update="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Update="CopyOnWrite" Version="0.3.1" />
+    <PackageReference Update="CopyOnWrite" Version="0.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
+++ b/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Build logic for staging artifacts from build outputs.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>

--- a/src/CopyOnWrite/Sdk/Sdk.targets
+++ b/src/CopyOnWrite/Sdk/Sdk.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
     <UsingTask
         TaskName="Copy"
-        AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Microsoft.Build.CopyOnWrite.dll"
+        AssemblyFile="$(MSBuildThisFileDirectory)..\build\netstandard2.0\Microsoft.Build.CopyOnWrite.dll"
         Condition="'$(EnableCopyOnWriteWin)' != 'false'"/>
 </Project>

--- a/src/CopyOnWrite/build/Microsoft.Build.CopyOnWrite.targets
+++ b/src/CopyOnWrite/build/Microsoft.Build.CopyOnWrite.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
     <UsingTask
         TaskName="Copy"
-        AssemblyFile="$(MSBuildThisFileDirectory)..\lib\netstandard2.0\Microsoft.Build.CopyOnWrite.dll"
+        AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.CopyOnWrite.dll"
         Condition="'$(EnableCopyOnWriteWin)' != 'false'"/>
 </Project>


### PR DESCRIPTION
This will avoid consumers including those dlls.