### PR TITLE
Avoid restoring net45 targeting pack in Traversal SDK

### DIFF
--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -186,6 +186,36 @@ namespace Microsoft.Build.Traversal.UnitTests
                 buildOutput.GetConsoleLog());
         }
 
+        [Theory]
+        [InlineData("AutomaticallyUseReferenceAssemblyPackages", "true", "true")]
+        [InlineData("AutomaticallyUseReferenceAssemblyPackages", null, "false")]
+        [InlineData("BuildInParallel", "false", "false")]
+        [InlineData("BuildInParallel", null, "true")]
+        [InlineData("ContinueOnError", "true", "true")]
+        [InlineData("ContinueOnError", null, "false")]
+        [InlineData("DisableImplicitFrameworkReferences", "false", "false")]
+        [InlineData("DisableImplicitFrameworkReferences", null, "true")]
+        [InlineData("EnableDefaultItems", null, "false")]
+        [InlineData("IsTraversal", null, "true")]
+        [InlineData("RestoreProjectStyle", null, "PackageReference")]
+        [InlineData("StopOnFirstFailure", "false", "false")]
+        [InlineData("StopOnFirstFailure", null, "true")]
+        [InlineData("TargetFramework", "net6.0", "net6.0")]
+        [InlineData("TargetFramework", null, "net45")]
+        [InlineData("TraversalProjectNames", "custom.proj", "custom.proj")]
+        [InlineData("TraversalProjectNames", null, "dirs.proj")]
+        [InlineData("UsingMicrosoftTraversalSdk", null, "true")]
+        public void PropertiesHaveExpectedValues(string propertyName, string value, string expectedValue)
+        {
+            ProjectCreator.Templates.TraversalProject(
+                path: GetTempFile("dirs.proj"))
+                .Property(propertyName, value)
+                .Save()
+                .TryGetPropertyValue(propertyName, out string actualValue);
+
+            actualValue.ShouldBe(expectedValue, StringComparer.OrdinalIgnoreCase, customMessage: $"Property {propertyName} should have a value of \"{expectedValue}\" but its value was \"{actualValue}\"");
+        }
+
         [Fact]
         public void PublishRespectsNoBuild()
         {

--- a/src/Traversal/Sdk/Sdk.props
+++ b/src/Traversal/Sdk/Sdk.props
@@ -8,6 +8,9 @@
 
   <PropertyGroup>
     <UsingMicrosoftTraversalSdk>true</UsingMicrosoftTraversalSdk>
+    
+    <!-- Don't automatically reference assembly packages since NoTargets don't need reference assemblies -->
+    <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>
 
   <Import Project="$(CustomBeforeTraversalProps)" Condition=" '$(CustomBeforeTraversalProps)' != '' And Exists('$(CustomBeforeTraversalProps)') " />
@@ -31,9 +34,6 @@
     
     <!-- Targeting packs shouldn't be referenced as traversal projects don't compile. -->
     <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">true</DisableImplicitFrameworkReferences>
-    
-    <!-- Don't automatically reference assembly packages since NoTargets don't need reference assemblies -->
-    <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(TraversalDoNotReferenceOutputAssemblies)' != 'false' ">

--- a/src/Traversal/Sdk/Sdk.props
+++ b/src/Traversal/Sdk/Sdk.props
@@ -31,6 +31,9 @@
     
     <!-- Targeting packs shouldn't be referenced as traversal projects don't compile. -->
     <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">true</DisableImplicitFrameworkReferences>
+    
+    <!-- Don't automatically reference assembly packages since NoTargets don't need reference assemblies -->
+    <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(TraversalDoNotReferenceOutputAssemblies)' != 'false' ">


### PR DESCRIPTION
The NoTargets SDK already sets the AutomaticallyUseReferenceAssemblyPackages property to false but the Traversal SDK didn't. As the Traversal SDK defines a default TFM (net45), the reference assembly pack is being downloaded automatically. This shows us as a prebuild in dotnet/runtime and other repositories that build from source.

cc @NikolaMilosavljevic 