### PR TITLE
Suppress package dependencies in msbuild sdk packages

### DIFF
--- a/src/CentralPackageVersions/Microsoft.Build.CentralPackageVersions.csproj
+++ b/src/CentralPackageVersions/Microsoft.Build.CentralPackageVersions.csproj
@@ -6,5 +6,6 @@
     <ArtifactsPath>$(BaseArtifactsPath)\$(MSBuildProjectName)\</ArtifactsPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageType>MSBuildSdk</PackageType>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 </Project>

--- a/src/NoTargets/Microsoft.Build.NoTargets.csproj
+++ b/src/NoTargets/Microsoft.Build.NoTargets.csproj
@@ -6,5 +6,6 @@
     <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageType>MSBuildSdk</PackageType>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 </Project>

--- a/src/Traversal/Microsoft.Build.Traversal.csproj
+++ b/src/Traversal/Microsoft.Build.Traversal.csproj
@@ -6,5 +6,6 @@
     <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageType>MSBuildSdk</PackageType>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes https://github.com/microsoft/MSBuildSdks/issues/431

Unrelated question: Why do the Traversal and the NoTargets projects target net40?