### PR TITLE
Make skipping of unsupported projects off by default

### DIFF
--- a/src/Traversal.UnitTests/SolutionTests.cs
+++ b/src/Traversal.UnitTests/SolutionTests.cs
@@ -32,12 +32,12 @@ namespace Microsoft.Build.Traversal.UnitTests
             ProjectCreator.Templates.SolutionMetaproj(
                 TestRootPath,
                 new[] { projectA, projectB })
+                .Property("TraversalSkipUnsupportedProjects", bool.TrueString)
                 .TryBuild("Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
 
             result.ShouldBeTrue();
 
-            buildOutput.Messages.High.ShouldHaveSingleItem()
-                .ShouldContain("Project B is skipped!");
+            buildOutput.Messages.High.ShouldContain(i => i.Contains("Project B is skipped!"));
 
             targetOutputs.TryGetValue("Build", out TargetResult buildTargetResult).ShouldBeTrue();
 

--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -432,12 +432,12 @@ namespace Microsoft.Build.Traversal.UnitTests
 
             ProjectCreator.Templates
                 .TraversalProject(new string[] { projectA, projectB }, path: GetTempFile("dirs.proj"))
+                .Property("TraversalSkipUnsupportedProjects", bool.TrueString)
                 .TryBuild("Build", out bool result, out BuildOutput buildOutput, out IDictionary<string, TargetResult> targetOutputs);
 
             result.ShouldBeTrue();
 
-            buildOutput.Messages.High.ShouldHaveSingleItem()
-                .ShouldContain("Project B is skipped!");
+            buildOutput.Messages.High.ShouldContain(i => i.Contains("Project B is skipped!"), buildOutput.GetConsoleLog());
 
             targetOutputs.TryGetValue("Build", out TargetResult buildTargetResult).ShouldBeTrue();
 
@@ -472,14 +472,7 @@ namespace Microsoft.Build.Traversal.UnitTests
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
 
-            buildOutput.Messages.High.ShouldBe(
-                    new[]
-                    {
-                        "BF0C6E1044514FE3AE4B78EC308D6F45",
-                        "40869F4000B44D75A52AB305F24E0FDB",
-                    },
-                    ignoreOrder: true,
-                    buildOutput.GetConsoleLog());
+            buildOutput.Messages.High.ShouldContain(i => string.Equals(i, "BF0C6E1044514FE3AE4B78EC308D6F45") || string.Equals(i, "40869F4000B44D75A52AB305F24E0FDB"), buildOutput.GetConsoleLog());
         }
 
         [Theory]

--- a/src/Traversal/README.md
+++ b/src/Traversal/README.md
@@ -59,8 +59,15 @@ This allows you to pass MSBuild global properties to skip a particular project:
 msbuild /Property:DoNotBuildWebApp=true
 ```
 
-Another method is to add a `ShouldSkipProject` target to your `Directory.Build.targets`.  Use the target below as a template:
+Another method is to enable skipping of unsupported projects by setting the `TraversalSkipUnsupportedProjects` MSBuild property in `Directory.Build.props`:
 
+```xml
+<PropertyGroup>
+  <TraversalSkipUnsupportedProjects>true</TraversalSkipUnsupportedProjects>
+</PropertyGroup>
+```
+
+Then you define a `ShouldSkipProject` target to your `Directory.Build.targets` that skips projects if they are unsupported.  Use the target below as a template:
 ```xml
 <Target Name="ShouldSkipProject" Returns="@(ProjectToSkip)">
   <ItemGroup>
@@ -89,6 +96,9 @@ in the same folder of any solution with the following contents:
 Directory.Solution.props:
 ```xml
 <Project>
+  <PropertyGroup>
+    <TraversalSkipUnsupportedProjects>true</TraversalSkipUnsupportedProjects>
+  </PropertyGroup>
   <Import Project="Microsoft.Build.Traversal" Project="Sdk.props" />
 </Project>
 ```

--- a/src/Traversal/Sdk/Sdk.targets
+++ b/src/Traversal/Sdk/Sdk.targets
@@ -13,7 +13,7 @@
 
   <Target Name="SkipProjects"
           DependsOnTargets="GetProjectsToSkip"
-          Condition="'$(SkipProjects)' != 'false'">
+          Condition="'$(TraversalSkipUnsupportedProjects)' == 'true'">
     <ItemGroup>
       <_NonExistentProjectToSkip Include="@(ProjectToSkip)" Condition="!Exists('%(ProjectToSkip.Identity)')"/>
       <ProjectReference Remove="%(ProjectToSkip.OriginalItemSpec)" />

--- a/src/Traversal/version.json
+++ b/src/Traversal/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "4.0"
+  "version": "4.1"
 }


### PR DESCRIPTION
Some users were hitting issues with the new feature of being able to skip projects which was on by default in 4.0.  This makes it off by default unless users enable it by setting `TraversalSkipUnsupportedProjects` to `true`.