### PR TITLE
Fix CoW Dependency

### DIFF
--- a/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
+++ b/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CopyOnWrite" GeneratePathProperty="True" PrivateAssets="All" />
-	  <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" ExcludeAssets="Runtime">
+	  <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" ExcludeAssets="Runtime" VersionOverride="16.9.0">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
   </ItemGroup>


### PR DESCRIPTION
The upgrade to CPM changed the version of MSBuild referenced (from 16.9 to 17.x).