### PR TITLE
Disable Artifacts if project is using .NET SDK's built-in artifacts functionality

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,5 +8,7 @@
     <NoWarn>$(NoWarn);NU5128;SA0001</NoWarn>
     <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
     <UseArtifactsOutput>false</UseArtifactsOutput>
+    <IsTestProject Condition="$(MSBuildProjectName.EndsWith('UnitTests'))">true</IsTestProject>
+    <IsPackable Condition="'$(IsTestProject)' != 'true'">true</IsPackable>
   </PropertyGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,24 +11,25 @@
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="16.9.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Update="Microsoft.Build.Tasks.Core" Version="15.9.20" Condition="'$(TargetFramework)' == 'net46'" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
-    <PackageVersion Include="MSBuild.ProjectCreation" Version="10.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="System.CodeDom" Version="7.0.0" />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="6.0.0" Condition=" '$(TargetFramework)' != 'net46' " />
     <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" Condition=" '$(TargetFramework)' == 'net46' " />
+  </ItemGroup>
+  <ItemGroup Condition="'$(IsTestProject)' == 'true'">
+    <PackageVersion Include="AssemblyShader" Version="1.0.3-preview" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="MSBuild.ProjectCreation" Version="10.0.0" />
+    <PackageVersion Include="Shouldly" Version="4.2.1" />
     <PackageVersion Include="xunit" Version="2.6.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>
-
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.Build.Artifacts" Version="6.0.6" Condition="'$(EnableArtifacts)' != 'false'" />
     <GlobalPackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" Condition="'$(EnableMicroBuild)' != 'false'" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" Condition="'$(EnableGitVersioning)' != 'false'" />
   </ItemGroup>
-
   <ItemGroup Condition=" '$(EnableStyleCop)' != 'false' ">
     <GlobalPackageReference Include="StyleCop.Analyzers" Version="1.1.118" />
     <Compile Include="$(MSBuildThisFileDirectory)src\GlobalSuppressions.cs" />

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -5,7 +5,7 @@ variables:
   ArtifactsDirectoryName: 'artifacts'
   BuildConfiguration: 'Release'
   BuildPlatform: 'Any CPU'
-  DotNetVersion: '7.x'
+  DotNetVersion: '8.x'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Test'
 
@@ -61,6 +61,7 @@ stages:
       displayName: 'Install .NET $(DotNetVersion)'
       inputs:
         version: '$(DotNetVersion)'
+        includePreviewVersions: true
 
     - task: MicroBuildSigningPlugin@4
       displayName: 'Install MicroBuild Signing Plugin'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,6 @@ variables:
   ArtifactsDirectoryName: 'artifacts'
   BuildConfiguration: 'Debug'
   BuildPlatform: 'Any CPU'
-  DotNet3Version: '3.x'
   DotNet6Version: '6.x'
   DotNet7Version: '7.x'
   DotNet8Version: '8.x'
@@ -38,11 +37,6 @@ jobs:
   steps:
 
   - task: UseDotNet@2
-    displayName: 'Install .NET Core $(DotNet3Version)'
-    inputs:
-      version: '$(DotNet3Version)'
-
-  - task: UseDotNet@2
     displayName: 'Install .NET $(DotNet6Version)'
     inputs:
       version: '$(DotNet6Version)'
@@ -70,14 +64,6 @@ jobs:
       command: 'test'
       arguments: '--no-restore --no-build --framework net472 /noautorsp'
       testRunTitle: 'Windows .NET Framework'
-    condition: succeededOrFailed()
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests (.NET Core 3.0)'
-    inputs:
-      command: 'test'
-      arguments: '--no-restore --no-build --framework netcoreapp3.1 /noautorsp'
-      testRunTitle: 'Windows .NET Core 3.0'
     condition: succeededOrFailed()
 
   - task: DotNetCoreCLI@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,6 +8,7 @@ variables:
   DotNet3Version: '3.x'
   DotNet6Version: '6.x'
   DotNet7Version: '7.x'
+  DotNet8Version: '8.x'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Test'
 
@@ -51,6 +52,12 @@ jobs:
     inputs:
       version: '$(DotNet7Version)'
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET $(DotNet8Version)'
+    inputs:
+      version: '$(DotNet8Version)'
+      includePreviewVersions: true
+
   - task: DotNetCoreCLI@2
     displayName: 'Build Solution'
     inputs:
@@ -81,6 +88,22 @@ jobs:
       testRunTitle: 'Windows .NET 6.0'
     condition: succeededOrFailed()
 
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 7.0)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net7.0 /noautorsp'
+      testRunTitle: 'Windows .NET 7.0'
+    condition: succeededOrFailed()
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 8.0)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net8.0 /noautorsp'
+      testRunTitle: 'Windows .NET 8.0'
+    condition: succeededOrFailed()
+
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifacts'
     inputs:
@@ -104,6 +127,12 @@ jobs:
     inputs:
       version: '$(DotNet7Version)'
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET $(DotNet8Version)'
+    inputs:
+      version: '$(DotNet8Version)'
+      includePreviewVersions: true
+
   - task: DotNetCoreCLI@2
     displayName: 'dotnet build'
     inputs:
@@ -116,6 +145,22 @@ jobs:
       command: 'test'
       arguments: '--no-restore --no-build --framework net6.0 /noautorsp'
       testRunTitle: 'Linux .NET 6.0'
+    condition: succeededOrFailed()
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 7.0)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net7.0 /noautorsp'
+      testRunTitle: 'Linux .NET 7.0'
+    condition: succeededOrFailed()
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 8.0)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net8.0 /noautorsp'
+      testRunTitle: 'Linux .NET 8.0'
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
@@ -141,6 +186,12 @@ jobs:
     inputs:
       version: '$(DotNet7Version)'
 
+  - task: UseDotNet@2
+    displayName: 'Install .NET $(DotNet8Version)'
+    inputs:
+      version: '$(DotNet8Version)'
+      includePreviewVersions: true
+
   - task: DotNetCoreCLI@2
     displayName: 'dotnet build'
     inputs:
@@ -153,6 +204,22 @@ jobs:
       command: 'test'
       arguments: '--no-restore --no-build --framework net6.0 /noautorsp'
       testRunTitle: 'MacOS .NET 6.0'
+    condition: succeededOrFailed()
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 7.0)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net7.0 /noautorsp'
+      testRunTitle: 'MacOS .NET 7.0'
+    condition: succeededOrFailed()
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Unit Tests (.NET 8.0)'
+    inputs:
+      command: 'test'
+      arguments: '--no-restore --no-build --framework net8.0 /noautorsp'
+      testRunTitle: 'MacOS .NET 8.0'
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1

--- a/src/Artifacts.UnitTests/ArtifactsTests.cs
+++ b/src/Artifacts.UnitTests/ArtifactsTests.cs
@@ -62,12 +62,13 @@ namespace Microsoft.Build.Artifacts.UnitTests
             string outputPath = $"{Path.Combine("bin", "Debug")}{Path.DirectorySeparatorChar}";
 
             ProjectCreator.Templates.ProjectWithArtifacts(
+                path: Path.Combine(TestRootPath, "ProjectA.csproj"),
                 outputPath: outputPath,
                 appendTargetFrameworkToOutputPath: false,
                 artifactsPath: artifactPaths)
-                .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
-                .TryGetPropertyValue("DefaultArtifactsSource", out string defaultArtifactsSource)
-                .TryBuild(out bool result, out BuildOutput buildOutput);
+                    .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
+                    .TryGetPropertyValue("DefaultArtifactsSource", out string defaultArtifactsSource)
+                    .TryBuild(out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
 
@@ -108,9 +109,10 @@ namespace Microsoft.Build.Artifacts.UnitTests
             DirectoryInfo distribPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
 
             ProjectCreator.Templates.ProjectWithArtifacts(
-                    outputPath: outputPath.FullName)
-                .ItemRobocopy(outputPath.FullName, distribPath.FullName, "*exe *dll *exe.config")
-                .TryBuild(out bool result, out BuildOutput buildOutput);
+                path: Path.Combine(TestRootPath, "ProjectA.csproj"),
+                outputPath: outputPath.FullName)
+                    .ItemRobocopy(outputPath.FullName, distribPath.FullName, "*exe *dll *exe.config")
+                    .TryBuild(out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
 
@@ -133,9 +135,10 @@ namespace Microsoft.Build.Artifacts.UnitTests
             string artifactsPath = Path.Combine(TestRootPath, "artifacts");
 
             ProjectCreator.Templates.ProjectWithArtifacts(
-                    artifactsPath: artifactsPath)
-                .Property(propertyName, actual)
-                .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems);
+                path: Path.Combine(TestRootPath, "ProjectA.csproj"),
+                artifactsPath: artifactsPath)
+                    .Property(propertyName, actual)
+                    .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems);
 
             ProjectItem artifactItem = artifactItems.ShouldHaveSingleItem();
 
@@ -166,12 +169,13 @@ namespace Microsoft.Build.Artifacts.UnitTests
             string outputPath = $"{(appendTargetFrameworkToOutputPath ? Path.Combine("bin", "Debug", "net472") : Path.Combine("bin", "Debug"))}{Path.DirectorySeparatorChar}";
 
             ProjectCreator.Templates.ProjectWithArtifacts(
+                path: Path.Combine(TestRootPath, "ProjectA.csproj"),
                 outputPath: outputPath,
                 appendTargetFrameworkToOutputPath: appendTargetFrameworkToOutputPath,
                 artifactsPath: artifactsPath.FullName)
-                .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
-                .TryGetPropertyValue("DefaultArtifactsSource", out string defaultArtifactsSource)
-                .TryBuild(out bool result, out BuildOutput buildOutput);
+                    .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
+                    .TryGetPropertyValue("DefaultArtifactsSource", out string defaultArtifactsSource)
+                    .TryBuild(out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
 
@@ -218,11 +222,12 @@ namespace Microsoft.Build.Artifacts.UnitTests
             DirectoryInfo artifactsPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
 
             ProjectCreator.Templates.ProjectWithArtifacts(
+                path: Path.Combine(TestRootPath, "ProjectA.csproj"),
                 outputPath: outputPath.FullName,
                 artifactsPath: artifactsPath.FullName)
-                .Property("DefaultArtifactsDirExclude", string.Join(separator, new[] { "one", "two" }))
-                .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
-                .TryBuild(out bool result, out BuildOutput buildOutput);
+                    .Property("DefaultArtifactsDirExclude", string.Join(separator, new[] { "one", "two" }))
+                    .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
+                    .TryBuild(out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
 
@@ -236,6 +241,31 @@ namespace Microsoft.Build.Artifacts.UnitTests
                         "foo.exe.config",
                     }.Select(i => Path.Combine(artifactsPath.FullName, i)),
                     ignoreOrder: true);
+        }
+
+        [Fact]
+        public void DisabledWhenBuiltInArtifactsEnabled()
+        {
+            DirectoryInfo projectDirectory = CreateFiles("ClassLibrary1");
+
+            ProjectCreator.Create()
+                .Property("UseArtifactsOutput", bool.TrueString)
+                .Property("ArtifactsPath", Path.Combine(TestRootPath, "artifacts"))
+                .Save(Path.Combine(TestRootPath, "Directory.Build.props"));
+
+            ProjectCreator.Templates.ProjectWithArtifacts(
+                path: Path.Combine(TestRootPath, "ProjectA.csproj"),
+                sdk: "Microsoft.NET.Sdk")
+                    .Save()
+                    .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> artifactItems)
+                    .TryGetPropertyValue("DefaultArtifactsSource", out string defaultArtifactsSource)
+                    .TryGetPropertyValue("EnableArtifacts", out string enableArtifacts)
+                    .TryGetPropertyValue("UsingMicrosoftArtifactsSdk", out string usingMicrosoftArtifactsSdk);
+
+            artifactItems.ShouldBeEmpty();
+            defaultArtifactsSource.ShouldBe(string.Empty);
+            enableArtifacts.ShouldBe(bool.FalseString, StringCompareShould.IgnoreCase);
+            usingMicrosoftArtifactsSdk.ShouldBe(string.Empty);
         }
 
         [Fact]
@@ -259,12 +289,13 @@ namespace Microsoft.Build.Artifacts.UnitTests
             string outputPath = $"{Path.Combine("bin", "Debug")}{Path.DirectorySeparatorChar}";
 
             ProjectCreator.Templates.ProjectWithArtifacts(
+                path: Path.Combine(TestRootPath, "ProjectA.csproj"),
                 outputPath: outputPath,
                 appendTargetFrameworkToOutputPath: false,
                 artifactsPath: artifactPaths)
-                .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> _)
-                .TryGetPropertyValue("DefaultArtifactsSource", out string _)
-                .TryBuild(out bool result, out BuildOutput buildOutput);
+                    .TryGetItems("Artifact", out IReadOnlyCollection<ProjectItem> _)
+                    .TryGetPropertyValue("DefaultArtifactsSource", out string _)
+                    .TryBuild(out bool result, out BuildOutput buildOutput);
 
             string consoleLog = buildOutput.GetConsoleLog();
             result.ShouldBeFalse(consoleLog);
@@ -329,6 +360,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
             DirectoryInfo artifactsPath = new DirectoryInfo(Path.Combine(TestRootPath, "artifacts"));
 
             ProjectCreator.Templates.SdkProjectWithArtifacts(
+                    path: Path.Combine(TestRootPath, "ProjectA.csproj"),
                     outputPath: appendTargetFrameworkToOutputPath ? Path.Combine("bin", "Debug", "net472") : Path.Combine("bin", "Debug"),
                     artifactsPath: artifactsPath.FullName,
                     appendTargetFrameworkToOutputPath: appendTargetFrameworkToOutputPath)

--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="AssemblyShader" />
     <PackageReference Include="CopyOnWrite" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"
+                      ShadeDependencies="NuGet.Frameworks"  />
     <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Shouldly" />

--- a/src/Artifacts/Microsoft.Build.Artifacts.csproj
+++ b/src/Artifacts/Microsoft.Build.Artifacts.csproj
@@ -15,19 +15,30 @@
     <Compile Include="..\Shared\CopyExceptionHandling.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CopyOnWrite" GeneratePathProperty="True" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
-    <PackageReference Include="System.Threading.Tasks.Dataflow" PrivateAssets="All" />
+    <PackageReference Include="CopyOnWrite"
+                      GeneratePathProperty="True"
+                      PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core"
+                      ExcludeAssets="Runtime"
+                      PrivateAssets="All" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow"
+                      PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="build\*" Pack="true" PackagePath="build\" />
-    <None Include="buildMultiTargeting\*" Pack="true" PackagePath="buildMultiTargeting\" />
+    <None Include="build\*"
+          Pack="true"
+          PackagePath="build\" />
+    <None Include="buildMultiTargeting\*"
+          Pack="true"
+          PackagePath="buildMultiTargeting\" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.Artifacts.UnitTests" />
   </ItemGroup>
   <ItemGroup>
-    <FilesToSign Include="$(TargetPath)" Authenticode="Microsoft400" StrongName="StrongName" />
+    <FilesToSign Include="$(TargetPath)"
+                 Authenticode="Microsoft400"
+                 StrongName="StrongName" />
   </ItemGroup>
   <Target Name="SignNuGetPackage" />
   <Target Name="CopyArtifacts"
@@ -37,17 +48,19 @@
     <ItemGroup>
       <Artifact Include="$(OutputPath)\**" />
     </ItemGroup>
-
     <Copy SourceFiles="@(Artifact)"
           DestinationFiles="@(Artifact->'$(ArtifactsPath)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)" />
   </Target>
-
-  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
+  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage"
+          BeforeTargets="_GetBuildOutputFilesWithTfm"
+          DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
     <ItemGroup>
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Artifacts/README.md
+++ b/src/Artifacts/README.md
@@ -14,6 +14,8 @@ to reproduce locally.  If your build stages artifacts as part of the overall bui
 hosted build environment.
 
 
+**NOTE: When using the .NET SDK's built-in artifacts functionality, the features of Microsoft.Build.Artifacts are disabled.**
+
 
 ## Example
 The source of artifacts default to the project's `$(OutputPath)`.  You simply need to specify a destination in order to have the artifacts staged for that project.

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.props
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.props
@@ -6,6 +6,12 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
+    <!--
+      Disable functionality if the project has opted into the .NET SDK's built-in artifacts functionality
+    -->
+    <EnableArtifacts Condition="'$(UseArtifactsOutput)' == 'true'">false</EnableArtifacts>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(EnableArtifacts)' != 'false'">
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
 
     <UsingMicrosoftArtifactsSdk>true</UsingMicrosoftArtifactsSdk>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -12,7 +12,7 @@
   <UsingTask TaskName="Robocopy"
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.Artifacts.dll'))" />
 
-  <ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(EnableArtifacts)' != 'false'">
     <Robocopy>
       <Visible>false</Visible>
       <VerifyExists>true</VerifyExists>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.targets
@@ -8,7 +8,7 @@
   <Import Project="$(CustomBeforeArtifactsTargets)"
           Condition="'$(CustomBeforeArtifactsTargets)' != '' And Exists('$(CustomBeforeArtifactsTargets)')" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(EnableArtifacts)' != 'false'">
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
 
     <!--
@@ -17,7 +17,7 @@
     <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == '' And '$(GeneratePackageOnBuild)' == 'true'">Pack</CopyArtifactsAfterTargets>
   </PropertyGroup>
 
-   <PropertyGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(DefaultArtifactsSource)' == '' And '$(TargetFrameworks)' == ''">
+   <PropertyGroup Condition="'$(EnableArtifacts)' != 'false' And '$(EnableDefaultArtifacts)' != 'false' And '$(DefaultArtifactsSource)' == '' And '$(TargetFrameworks)' == ''">
       <!--
          Default artifacts source is the output path unless AppendTargetFrameworkToOutputPath is true in which case the parent folder is the default.
        -->
@@ -26,7 +26,7 @@
       <DefaultArtifactsSource Condition="'$(AppendTargetFrameworkToOutputPath)' == 'true' And $(OutputPath.EndsWith('/'))">$([System.IO.Path]::GetDirectoryName($(OutputPath.TrimEnd('/'))))/</DefaultArtifactsSource>
    </PropertyGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$(DefaultArtifactsSource)' != '' And '$(TargetFrameworks)' == ''">
+  <ItemGroup Condition="'$(EnableArtifacts)' != 'false' And '$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$(DefaultArtifactsSource)' != '' And '$(TargetFrameworks)' == ''">
     <!--
       By default copy the contents of $(DefaultArtifactsSource) (default is $(OutputPath)) to $(ArtifactsPath) unless:
        * EnableDefaultArtifacts is 'false'

--- a/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/buildMultiTargeting/Microsoft.Build.Artifacts.targets
@@ -8,7 +8,7 @@
   <Import Project="$(CustomBeforeArtifactsTargets)"
           Condition="'$(CustomBeforeArtifactsTargets)' != '' And Exists('$(CustomBeforeArtifactsTargets)')" />
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(EnableArtifacts)' != 'false'">
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
 
     <!--
@@ -22,7 +22,7 @@
     <CopyArtifactsAfterTargets Condition="'$(CopyArtifactsAfterTargets)' == ''">Build</CopyArtifactsAfterTargets>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != ''">
+  <ItemGroup Condition="'$(EnableArtifacts)' != 'false' And '$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$([MSBuild]::ValueOrDefault($(DefaultArtifactsSource), $(OutputPath)))' != ''">
     <!--
       By default copy the contents of $(DefaultArtifactsSource) (default is $(OutputPath)) to $(ArtifactsPath) unless:
        * EnableDefaultArtifacts is 'false'

--- a/src/Artifacts/version.json
+++ b/src/Artifacts/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "6.0"
+  "version": "6.1"
 }

--- a/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
+++ b/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
@@ -12,10 +11,15 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CentralPackageVersions\Microsoft.Build.CentralPackageVersions.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\CentralPackageVersions\Microsoft.Build.CentralPackageVersions.csproj"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\CentralPackageVersions\Sdk\Sdk.props" Link="Sdk\Sdk.props" CopyToOutputDirectory="PreserveNewest" />
-    <None Include="..\CentralPackageVersions\Sdk\Sdk.targets" Link="Sdk\Sdk.targets" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\CentralPackageVersions\Sdk\Sdk.props"
+          Link="Sdk\Sdk.props"
+          CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\CentralPackageVersions\Sdk\Sdk.targets"
+          Link="Sdk\Sdk.targets"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/CopyOnWrite.UnitTests/Microsoft.Build.CopyOnWrite.UnitTests.csproj
+++ b/src/CopyOnWrite.UnitTests/Microsoft.Build.CopyOnWrite.UnitTests.csproj
@@ -1,9 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
     <Nullable>Enable</Nullable>
-
     <!-- Suppress "Error : System.CodeDom 7.0.0 doesn't support netcoreapp3.1 and has not been tested with it." -->
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>

--- a/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
+++ b/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
@@ -12,11 +12,9 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>    
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Include="..\Shared\CopyExceptionHandling.cs" />
   </ItemGroup>
-
   <ItemGroup>
     <None Include="build\Microsoft.Build.CopyOnWrite.targets">
       <PackagePath>build\</PackagePath>
@@ -25,24 +23,31 @@
     <None Include=".editorconfig" />
   </ItemGroup>
   <ItemGroup>
-    <FilesToSign Include="$(TargetPath)" Authenticode="Microsoft400" StrongName="StrongName" />
+    <FilesToSign Include="$(TargetPath)"
+                 Authenticode="Microsoft400"
+                 StrongName="StrongName" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="CopyOnWrite" GeneratePathProperty="True" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="all" ExcludeAssets="Runtime">
-      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
+    <PackageReference Include="CopyOnWrite"
+                      GeneratePathProperty="True"
+                      PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core"
+                      PrivateAssets="all"
+                      ExcludeAssets="Runtime"
+                      IncludeAssets="compile; build; native; contentfiles; analyzers; buildtransitive" />
   </ItemGroup>
-
-  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
+  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage"
+          BeforeTargets="_GetBuildOutputFilesWithTfm"
+          DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
     <ItemGroup>
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
-      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
     </ItemGroup>
   </Target>
 
   <ItemGroup>
     <InternalsVisibleTo Include="Microsoft.Build.CopyOnWrite.UnitTests" />
   </ItemGroup>
-
 </Project>

--- a/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
+++ b/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="AssemblyShader" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"
+                      ShadeDependencies="NuGet.Frameworks"  />
     <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Shouldly" />
@@ -12,9 +13,12 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\NoTargets\Microsoft.Build.NoTargets.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\NoTargets\Microsoft.Build.NoTargets.csproj"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\NoTargets\Sdk\**\*" Link="Sdk\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\NoTargets\Sdk\**\*"
+          Link="Sdk\%(RecursiveDir)%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>

--- a/src/TestShared/MSBuildSdkTestBase.cs
+++ b/src/TestShared/MSBuildSdkTestBase.cs
@@ -17,7 +17,6 @@ namespace Microsoft.Build.UnitTests.Common
     public abstract class MSBuildSdkTestBase : MSBuildTestBase, IDisposable
     {
         private readonly string _testRootPath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
-        private readonly string _previousCurrentDirectory = Environment.CurrentDirectory;
 
         protected MSBuildSdkTestBase()
         {
@@ -30,8 +29,6 @@ namespace Microsoft.Build.UnitTests.Common
     <add key=""NuGet.org"" value=""https://api.nuget.org/v3/index.json"" />
   </packageSources>
 </configuration>");
-
-            Environment.CurrentDirectory = TestRootPath;
         }
 
         protected bool IsWindows { get; } = Environment.OSVersion.Platform == PlatformID.Win32NT;
@@ -67,7 +64,6 @@ namespace Microsoft.Build.UnitTests.Common
 
         protected virtual void Dispose(bool disposing)
         {
-            Environment.CurrentDirectory = _previousCurrentDirectory;
             if (disposing)
             {
                 if (Directory.Exists(TestRootPath))

--- a/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
+++ b/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
@@ -1,10 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp3.1;net6.0</TargetFrameworks>
-    <IsPackable>false</IsPackable>
+    <TargetFrameworks>net472;netcoreapp3.1;net6.0;net7.0;net8.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="AssemblyShader" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk"
+                      ShadeDependencies="NuGet.Frameworks"  />
     <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Shouldly" />
@@ -12,9 +13,12 @@
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Traversal\Microsoft.Build.Traversal.csproj" ReferenceOutputAssembly="false" />
+    <ProjectReference Include="..\Traversal\Microsoft.Build.Traversal.csproj"
+                      ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\Traversal\Sdk\**" Link="Sdk\$(RelativeDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
+    <None Include="..\Traversal\Sdk\**"
+          Link="Sdk\$(RelativeDir)%(Filename)%(Extension)"
+          CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
If a user has opted into the .NET SDK's artifacts functionality by setting the MSBuild property `UseArtifactsOutput`, then disable Microsoft.Build.Artifacts since you would only want to be using one or the other.

Also enables the pipeline to run tests against .NET 7.0 and .NET 8 while no longer running against .NET Core 3