### PR TITLE
Add parallelism and copy-on-write links to Robocopy task

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,7 @@
     <MicrosoftBuildPackageVersion>17.6.3</MicrosoftBuildPackageVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="CopyOnWrite" Version="0.3.6" Condition=" '$(TargetFramework)' != 'net46' " />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="16.9.0" Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'netstandard2.0'" />
     <PackageVersion Update="Microsoft.Build.Utilities.Core" Version="15.9.20" Condition="'$(TargetFramework)' == 'net46'" />
@@ -15,9 +16,10 @@
     <PackageVersion Include="MSBuild.ProjectCreation" Version="10.0.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="6.0.0" Condition=" '$(TargetFramework)' != 'net46' "/>
+    <PackageVersion Include="System.Threading.Tasks.Dataflow" Version="4.11.1" Condition=" '$(TargetFramework)' == 'net46' "/>
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="CopyOnWrite" Version="0.3.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="Newtonsoft.Json" />
     <PackageReference Include="Shouldly" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
   </ItemGroup>

--- a/src/Artifacts.UnitTests/RobocopyTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyTests.cs
@@ -7,14 +7,32 @@ using Microsoft.Build.Framework;
 using Microsoft.Build.UnitTests.Common;
 using Microsoft.Build.Utilities.ProjectCreation;
 using Shouldly;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using Xunit;
+
+#nullable enable
 
 namespace Microsoft.Build.Artifacts.UnitTests
 {
     public class RobocopyTests : MSBuildSdkTestBase
     {
+        private static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
+        [Fact]
+        public void DedupKeyOsDifferences()
+        {
+            var lowercase = new Robocopy.CopyFileDedupKey("foo", "bar");
+            var uppercase = new Robocopy.CopyFileDedupKey("FOO", "BAR");
+            Robocopy.CopyFileDedupKey.ComparerInstance.Equals(lowercase, uppercase).ShouldBe(IsWindows);
+            (Robocopy.CopyFileDedupKey.ComparerInstance.GetHashCode(lowercase) ==
+             Robocopy.CopyFileDedupKey.ComparerInstance.GetHashCode(uppercase)).ShouldBe(IsWindows);
+        }
+
         [Fact]
         public void NonRecursiveWildcards()
         {
@@ -30,7 +48,6 @@ namespace Microsoft.Build.Artifacts.UnitTests
                 Path.Combine("baz", "baz.txt"));
 
             DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
-
             BuildEngine buildEngine = BuildEngine.Create();
 
             Robocopy copyArtifacts = new Robocopy
@@ -45,10 +62,14 @@ namespace Microsoft.Build.Artifacts.UnitTests
                         [nameof(RobocopyMetadata.IsRecursive)] = "false",
                     },
                 },
-                Sleep = duration => { },
+                Sleep = _ => { },
             };
 
             copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(2);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
 
             destination.GetFiles("*", SearchOption.AllDirectories)
                 .Select(i => i.FullName)
@@ -58,7 +79,8 @@ namespace Microsoft.Build.Artifacts.UnitTests
                         "bar.txt",
                         "foo.txt",
                     }.Select(i => Path.Combine(destination.FullName, i)),
-                    ignoreOrder: true);
+                    ignoreOrder: true,
+                    customMessage: buildEngine.GetConsoleLog());
         }
 
         [Fact]
@@ -95,10 +117,14 @@ namespace Microsoft.Build.Artifacts.UnitTests
                         ["FileMatch"] = "*exe *dll *exe.config",
                     },
                 },
-                Sleep = duration => { },
+                Sleep = _ => { },
             };
 
             copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(5);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
 
             destination.GetFiles("*", SearchOption.AllDirectories)
                 .Select(i => i.FullName)
@@ -111,7 +137,8 @@ namespace Microsoft.Build.Artifacts.UnitTests
                         "foo.exe.config",
                         Path.Combine("baz", "baz.dll"),
                     }.Select(i => Path.Combine(destination.FullName, i)),
-                    ignoreOrder: true);
+                    ignoreOrder: true,
+                    customMessage: buildEngine.GetConsoleLog());
         }
 
         [Fact]
@@ -148,17 +175,23 @@ namespace Microsoft.Build.Artifacts.UnitTests
                         ["FileMatch"] = "foo.pdb",
                     },
                 },
-                Sleep = duration => { },
+                Sleep = _ => { },
             };
 
             copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(1);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
 
             destination.GetFiles("*", SearchOption.AllDirectories)
                 .Select(i => i.FullName)
-                .ShouldBe(new[]
-                {
-                    "foo.pdb",
-                }.Select(i => Path.Combine(destination.FullName, i)));
+                .ShouldBe(
+                    new[]
+                    {
+                        "foo.pdb",
+                    }.Select(i => Path.Combine(destination.FullName, i)),
+                    customMessage: buildEngine.GetConsoleLog());
         }
 
         [Fact]
@@ -196,18 +229,389 @@ namespace Microsoft.Build.Artifacts.UnitTests
                         ["FileMatch"] = "foo.pdb",
                     },
                 },
-                Sleep = duration => { },
+                Sleep = _ => { },
             };
 
             copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(2);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
 
             destination.GetFiles("*", SearchOption.AllDirectories)
                 .Select(i => i.FullName)
-                .ShouldBe(new[]
+                .ShouldBe(
+                    new[]
+                    {
+                        "foo.pdb",
+                        Path.Combine("foo", "foo", "foo", "foo.pdb"),
+                    }.Select(i => Path.Combine(destination.FullName, i)),
+                    customMessage: buildEngine.GetConsoleLog());
+        }
+
+        [Fact]
+        public void DuplicatedItemsShouldResultInOneCopy()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+            BuildEngine buildEngine = BuildEngine.Create();
+            MockFileSystem fs = new MockFileSystem
+            {
+                // Ensure same test result whether on NTFS or ReFS.
+                TryCloneFileFunc = (_, _) => false,
+            };
+
+            MockTaskItem singleFileItem = new MockTaskItem(Path.Combine(source.FullName, "foo.txt"))
+            {
+                ["DestinationFolder"] = destination.FullName,
+            };
+
+            MockTaskItem recursiveDirItem = new MockTaskItem(source.FullName)
+            {
+                ["DestinationFolder"] = destination.FullName,
+            };
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
                 {
-                    "foo.pdb",
-                    Path.Combine("foo", "foo", "foo", "foo.pdb"),
-                }.Select(i => Path.Combine(destination.FullName, i)));
+                    singleFileItem,
+                    singleFileItem,
+                    singleFileItem,
+                    singleFileItem,
+                    singleFileItem,
+                    singleFileItem,
+
+                    recursiveDirItem,
+                    recursiveDirItem,
+                    recursiveDirItem,
+                    recursiveDirItem,
+                    recursiveDirItem,
+                    recursiveDirItem,
+                },
+                Sleep = _ => { },
+                FileSystem = fs,
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(1);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
+            fs.NumCloneFileCalls.ShouldBe(1);
+            fs.NumCopyFileCalls.ShouldBe(1);
+
+            destination.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(
+                    new[]
+                    {
+                        "foo.txt",
+                    }.Select(i => Path.Combine(destination.FullName, i)),
+                    customMessage: buildEngine.GetConsoleLog());
+        }
+
+        [Fact]
+        public void SelfCopiesShouldNoOp()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt");
+
+            BuildEngine buildEngine = BuildEngine.Create();
+            MockFileSystem fs = new MockFileSystem();
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(Path.Combine(source.FullName, "foo.txt"))
+                    {
+                        ["DestinationFolder"] = source.FullName,
+                    },
+                    new MockTaskItem(source.FullName)
+                    {
+                        ["DestinationFolder"] = source.FullName,
+                    },
+                },
+                Sleep = _ => { },
+                FileSystem = fs,
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(0);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(1);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
+            fs.NumCloneFileCalls.ShouldBe(0);
+            fs.NumCopyFileCalls.ShouldBe(0);
+        }
+
+        [Fact]
+        public void DifferentSourcesSameDestinationShouldRunDuplicatesSeparately()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                Path.Combine("source1", "foo.txt"),
+                Path.Combine("source2", "foo.txt"),
+                Path.Combine("source3", "foo.txt"));
+
+            BuildEngine buildEngine = BuildEngine.Create();
+            MockFileSystem fs = new MockFileSystem();
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(Path.Combine(source.FullName, "source1", "foo.txt"))
+                    {
+                        ["DestinationFolder"] = source.FullName,
+                        ["AlwaysCopy"] = "true",  // Bypass timestamp check.
+                    },
+                    new MockTaskItem(Path.Combine(source.FullName, "source2", "foo.txt"))
+                    {
+                        ["DestinationFolder"] = source.FullName,
+                        ["AlwaysCopy"] = "true",
+                    },
+                    new MockTaskItem(Path.Combine(source.FullName, "source3", "foo.txt"))
+                    {
+                        ["DestinationFolder"] = source.FullName,
+                        ["AlwaysCopy"] = "true",
+                    },
+                },
+                Sleep = _ => { },
+                FileSystem = fs,
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(3, buildEngine.GetConsoleLog());
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(2);
+            fs.NumCloneFileCalls.ShouldBe(3);
+        }
+
+        [Fact]
+        public void CoWSuccessDoesNotCopy()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            MockFileSystem fs = new MockFileSystem
+            {
+                TryCloneFileFunc = (src, dst) =>
+                {
+                    src.FullName.ShouldBe(Path.Combine(source.FullName, "foo.txt"));
+                    dst.FullName.ShouldBe(Path.Combine(destination.FullName, "foo.txt"));
+
+                    // Make an actual copy since the logic will read and update attributes.
+                    File.Copy(src.FullName, dst.FullName);
+
+                    return true;
+                },
+            };
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(Path.Combine(source.FullName, "foo.txt"))
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                    },
+                },
+                Sleep = _ => { },
+                FileSystem = fs,
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(1);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
+            fs.NumCloneFileCalls.ShouldBe(1);
+            fs.NumCopyFileCalls.ShouldBe(0);
+        }
+
+        [Fact]
+        public void DisablingCoWJustCopies()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+            BuildEngine buildEngine = BuildEngine.Create();
+            MockFileSystem fs = new MockFileSystem();
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                DisableCopyOnWrite = true,
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(Path.Combine(source.FullName, "foo.txt"))
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                    },
+                },
+                Sleep = _ => { },
+                FileSystem = fs,
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(1);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
+            fs.NumCloneFileCalls.ShouldBe(0);
+            fs.NumCopyFileCalls.ShouldBe(1);
+
+            destination.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(
+                    new[]
+                    {
+                        "foo.txt",
+                    }.Select(i => Path.Combine(destination.FullName, i)),
+                    customMessage: buildEngine.GetConsoleLog());
+        }
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public void CoWExceptionFallsBackToCopy(bool win32ExWithSharingViolation)
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                @"foo.txt");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            MockFileSystem fs = new MockFileSystem
+            {
+                TryCloneFileFunc = (_, _) =>
+                {
+                    if (win32ExWithSharingViolation)
+                    {
+                        throw new Win32Exception(Robocopy.ErrorSharingViolation, "Mock sharing exception");
+                    }
+
+                    throw new Win32Exception(1);
+                },
+            };
+
+            Robocopy copyArtifacts = new Robocopy
+            {
+                BuildEngine = buildEngine,
+                Sources = new ITaskItem[]
+                {
+                    new MockTaskItem(Path.Combine(source.FullName, "foo.txt"))
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                    },
+                },
+                Sleep = _ => { },
+                FileSystem = fs,
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(1);
+            copyArtifacts.NumErrors.ShouldBe(0);
+            copyArtifacts.NumFilesSkipped.ShouldBe(0);
+            copyArtifacts.NumDuplicateDestinationDelayedJobs.ShouldBe(0);
+            fs.NumCloneFileCalls.ShouldBe(1);
+            fs.NumCopyFileCalls.ShouldBe(1);
+
+            destination.GetFiles("*", SearchOption.AllDirectories)
+                .Select(i => i.FullName)
+                .ShouldBe(
+                    new[]
+                    {
+                        "foo.txt",
+                    }.Select(i => Path.Combine(destination.FullName, i)),
+                    customMessage: buildEngine.GetConsoleLog());
+        }
+
+        private sealed class MockFileSystem : IFileSystem
+        {
+            private int _numCloneFileCalls;
+            private int _numCopyFileCalls;
+
+            public Func<FileInfo, FileInfo, bool>? TryCloneFileFunc { get; set; }
+
+            public int NumCloneFileCalls => _numCloneFileCalls;
+
+            public int NumCopyFileCalls => _numCopyFileCalls;
+
+            public FileInfo CopyFile(FileInfo source, string destination, bool overwrite)
+            {
+                Interlocked.Increment(ref _numCopyFileCalls);
+                return FileSystem.Instance.CopyFile(source, destination, overwrite);
+            }
+
+            public DirectoryInfo CreateDirectory(string path) => FileSystem.Instance.CreateDirectory(path);
+
+            public bool DirectoryExists(string path) => FileSystem.Instance.DirectoryExists(path);
+
+            public IEnumerable<string> EnumerateDirectories(
+                string path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            {
+                return FileSystem.Instance.EnumerateDirectories(path, searchPattern, searchOption);
+            }
+
+            public IEnumerable<DirectoryInfo> EnumerateDirectories(
+                DirectoryInfo path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            {
+                return FileSystem.Instance.EnumerateDirectories(path, searchPattern, searchOption);
+            }
+
+            public IEnumerable<string> EnumerateFiles(
+                string path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            {
+                return FileSystem.Instance.EnumerateFiles(path, searchPattern, searchOption);
+            }
+
+            public IEnumerable<FileInfo> EnumerateFiles(
+                DirectoryInfo path,
+                string searchPattern = "*",
+                SearchOption searchOption = SearchOption.TopDirectoryOnly)
+            {
+                return FileSystem.Instance.EnumerateFiles(path, searchPattern, searchOption);
+            }
+
+            public bool FileExists(string path) => FileSystem.Instance.FileExists(path);
+
+            public bool FileExists(FileInfo file) => FileSystem.Instance.FileExists(file);
+
+            public bool TryCloneFile(FileInfo sourceFile, FileInfo destinationFile)
+            {
+                Interlocked.Increment(ref _numCloneFileCalls);
+                if (TryCloneFileFunc is null)
+                {
+                    return FileSystem.Instance.TryCloneFile(sourceFile, destinationFile);
+                }
+
+                return TryCloneFileFunc(sourceFile, destinationFile);
+            }
         }
     }
 }

--- a/src/Artifacts/FileSystem.cs
+++ b/src/Artifacts/FileSystem.cs
@@ -2,62 +2,119 @@
 //
 // Licensed under the MIT license.
 
+#if NETSTANDARD2_0_OR_GREATER
+using Microsoft.CopyOnWrite;
+#endif
+using System;
 using System.Collections.Generic;
 using System.IO;
+
+#nullable enable
 
 namespace Microsoft.Build.Artifacts
 {
     internal sealed class FileSystem : IFileSystem
     {
+#if NETSTANDARD2_0_OR_GREATER
+        private static readonly ICopyOnWriteFilesystem CoW = CopyOnWriteFilesystemFactory.GetInstance();
+#endif
+
+        private static readonly bool IsWindows = Environment.OSVersion.Platform == PlatformID.Win32NT;
+
         private FileSystem()
         {
         }
 
+        /// <summary>
+        /// Gets the OS-specific path comparison.
+        /// </summary>
+        public static StringComparison PathComparison { get; } = IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+        /// <summary>
+        /// Gets the OS-specific path comparer.
+        /// </summary>
+        public static StringComparer PathComparer { get; } = IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        /// <summary>
+        /// Gets a singleton instance of this class.
+        /// </summary>
         public static FileSystem Instance { get; } = new FileSystem();
 
+        /// <inheritdoc/>
         public FileInfo CopyFile(FileInfo source, string destFileName, bool overwrite)
         {
             return source.CopyTo(destFileName, overwrite);
         }
 
+        /// <inheritdoc/>
         public DirectoryInfo CreateDirectory(string path)
         {
             return Directory.CreateDirectory(path);
         }
 
+        /// <inheritdoc/>
         public bool DirectoryExists(string path)
         {
             return Directory.Exists(path);
         }
 
+        /// <inheritdoc/>
         public IEnumerable<DirectoryInfo> EnumerateDirectories(DirectoryInfo path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return path.EnumerateDirectories(searchPattern, searchOption);
         }
 
+        /// <inheritdoc/>
         public IEnumerable<string> EnumerateDirectories(string path, string searchPattern, SearchOption searchOption)
         {
             return Directory.EnumerateDirectories(path, searchPattern, searchOption);
         }
 
+        /// <inheritdoc/>
         public IEnumerable<string> EnumerateFiles(string path, string searchPattern, SearchOption searchOption)
         {
             return Directory.EnumerateFiles(path, searchPattern, searchOption);
         }
 
+        /// <inheritdoc/>
         public IEnumerable<FileInfo> EnumerateFiles(DirectoryInfo path, string searchPattern = "*", SearchOption searchOption = SearchOption.TopDirectoryOnly)
         {
             return path.EnumerateFiles(searchPattern, searchOption);
         }
 
+        /// <inheritdoc/>
         public bool FileExists(string path)
         {
             return File.Exists(path);
         }
 
+        /// <inheritdoc/>
         public bool FileExists(FileInfo file)
         {
             return file.Exists;
         }
-    }
+
+        /// <inheritdoc/>
+        public bool TryCloneFile(FileInfo sourceFile, FileInfo destinationFile)
+        {
+#if NETSTANDARD2_0_OR_GREATER
+            string sourcePath = sourceFile.FullName;
+            string destPath = destinationFile.FullName;
+            if (CoW.CopyOnWriteLinkSupportedBetweenPaths(sourcePath, destPath, pathsAreFullyResolved: true))
+            {
+                if (destinationFile.Exists)
+                {
+                    // CoW doesn't overwrite destination files.
+                    destinationFile.Delete();
+                }
+
+                // PathIsFullyResolved: FileInfo.FullName is fully resolved.
+                CoW.CloneFile(sourcePath, destPath, CloneFlags.PathIsFullyResolved);
+                return true;
+            }
+#endif
+
+            return false;
+        }
+   }
 }

--- a/src/Artifacts/IFileSystem.cs
+++ b/src/Artifacts/IFileSystem.cs
@@ -2,12 +2,15 @@
 //
 // Licensed under the MIT license.
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 
+#nullable enable
+
 namespace Microsoft.Build.Artifacts
 {
-    internal interface IFileSystem
+    public interface IFileSystem
     {
         FileInfo CopyFile(FileInfo source, string destination, bool overwrite);
 
@@ -26,5 +29,11 @@ namespace Microsoft.Build.Artifacts
         bool FileExists(string path);
 
         bool FileExists(FileInfo file);
+
+        /// <summary>
+        /// Attempts to create a copy-on-write link (file clone) if supported.
+        /// </summary>
+        /// <returns>True if the clone was created, false if unsupported.</returns>
+        bool TryCloneFile(FileInfo sourceFile, FileInfo destinationFile);
     }
 }

--- a/src/Artifacts/Microsoft.Build.Artifacts.csproj
+++ b/src/Artifacts/Microsoft.Build.Artifacts.csproj
@@ -12,7 +12,9 @@
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CopyOnWrite" Condition="'$(TargetFramework)' != 'net46'" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
+    <PackageReference Include="System.Threading.Tasks.Dataflow" />
   </ItemGroup>
   <ItemGroup>
     <None Include="build\*" Pack="true" PackagePath="build\" />

--- a/src/Artifacts/README.md
+++ b/src/Artifacts/README.md
@@ -147,6 +147,7 @@ The following properties control artifacts staging:
 | `ArtifactsCopyRetryDelayMilliseconds` | The number of milliseconds to wait in between retries | `$(CopyRetryDelayMilliseconds)` |
 | `ArtifactsShowDiagnostics` | Enables additional logging that can be used to troubleshoot why artifacts are not being staged | `false` |
 | `ArtifactsShowErrorOnRetry` | Logs an error if a retry was attempted.  Disable this to suppress issues while copying files | `true` |
+| `DisableCopyOnWrite` | Disables use of copy-on-write links (file cloning) even if the filesystem allows it. | `false` |
 | `CustomBeforeArtifactsProps ` | A list of custom MSBuild projects to import **before** artifacts properties are declared. |
 | `CustomAfterArtifactsProps` | A list of custom MSBuild projects to import **after** Artifacts properties are declared.|
 | `CustomBeforeArtifactsTargets` | A list of custom MSBuild projects to import **before** Artifacts targets are declared.|

--- a/src/Artifacts/Tasks/Robocopy.cs
+++ b/src/Artifacts/Tasks/Robocopy.cs
@@ -5,54 +5,175 @@
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Threading;
+using System.Threading.Tasks.Dataflow;
+
+#nullable enable
 
 namespace Microsoft.Build.Artifacts.Tasks
 {
+    /// <summary>
+    /// MSBuild Task that copies files and directories.
+    /// </summary>
     public class Robocopy : Task
     {
-        private TimeSpan _retryWaitInMilliseconds = TimeSpan.Zero;
+        internal const int ErrorSharingViolation = 32;
 
+        // Similar but somewhat higher parallelism vs. MSBuild Copy task https://github.com/dotnet/msbuild/blob/main/src/Tasks/Copy.cs
+        private static readonly int DefaultCopyParallelism = Environment.ProcessorCount > 4 ? 8 : 4;
+        private static readonly int MsBuildCopyParallelism = GetMsBuildCopyTaskParallelism();
+        private static readonly ExecutionDataflowBlockOptions ActionBlockOptions = new () { MaxDegreeOfParallelism = MsBuildCopyParallelism, EnsureOrdered = MsBuildCopyParallelism == 1 };
+
+        private readonly ConcurrentDictionary<string, bool> _dirsCreated = new (Artifacts.FileSystem.PathComparer);
+        private readonly Dictionary<string, string> _realDirPaths = new (Artifacts.FileSystem.PathComparer);  // Cache results of symlink resolution to avoid I/O.
+        private readonly HashSet<string> _destinationPathsStarted = new (Artifacts.FileSystem.PathComparer);  // Destination paths that were dispatched to copy. Extra copies to the same destination are copied single-threaded in a second wave.
+        private readonly List<CopyJob> _duplicateDestinationDelayedJobs = new ();  // Jobs that were delayed because they were to a destination path that was already dispatched to copy.
+        private readonly ActionBlock<CopyJob> _copyFileBlock;
+        private readonly HashSet<CopyFileDedupKey> _filesCopied = new (CopyFileDedupKey.ComparerInstance);
+        private TimeSpan _retryWaitInMilliseconds = TimeSpan.Zero;
+        private int _numFilesCopied;
+        private int _numFilesSkipped;
+        private int _numErrors;
+
+        public Robocopy()
+        {
+            _copyFileBlock = new (async job =>
+            {
+                // Break from synchronous thread context of caller to get onto global thread pool thread for synchronous copy operations.
+                await System.Threading.Tasks.Task.Yield();
+                CopyFileImpl(job.SourceFile, job.DestFile, job.Metadata);
+            }, ActionBlockOptions);
+        }
+
+        /// <summary>
+        /// Gets or sets the number of retries to perform on each file on failure.
+        /// </summary>
         public int RetryCount { get; set; }
 
+        /// <summary>
+        /// Gets or sets the interval between retries, in milliseconds.
+        /// </summary>
         public int RetryWait { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to log diagnostic trace messages.
+        /// </summary>
         public bool ShowDiagnosticTrace { get; set; }
 
+        /// <summary>
+        /// Gets or sets a value indicating whether to log errors on retries
+        /// </summary>
         public bool ShowErrorOnRetry { get; set; }
 
+        /// <summary>
+        /// Gets or sets the source files and directories to copy.
+        /// </summary>
         [Required]
-        public ITaskItem[] Sources { get; set; }
+        public ITaskItem[] Sources { get; set; } = Array.Empty<ITaskItem>();
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to disable copy-on-write linking if the links are available.
+        /// </summary>
+        public bool DisableCopyOnWrite { get; set; }
 
         internal IFileSystem FileSystem { get; set; } = Artifacts.FileSystem.Instance;
 
         internal Action<TimeSpan> Sleep { get; set; } = Thread.Sleep;
 
+        internal int NumFilesCopied => _numFilesCopied;
+
+        internal int NumFilesSkipped => _numFilesSkipped;
+
+        internal int NumErrors => _numErrors;
+
+        internal int NumDuplicateDestinationDelayedJobs => _duplicateDestinationDelayedJobs.Count;
+
+        /// <inheritdoc/>
         public override bool Execute()
         {
             RetryCount = Math.Max(0, RetryCount);
             _retryWaitInMilliseconds = RetryWait < 0 ? TimeSpan.Zero : TimeSpan.FromMilliseconds(RetryWait);
 
-            int count = 0;
             foreach (IList<RobocopyMetadata> bucket in GetBuckets())
             {
                 CopyItems(bucket);
-                count++;
             }
 
-            Log.LogMessage("Processed {0} bucket(s)", count);
+            _copyFileBlock.Complete();
+            _copyFileBlock.Completion.GetAwaiter().GetResult();
+
+            if (_duplicateDestinationDelayedJobs.Count > 0)
+            {
+                Log.LogMessage("Finishing {0} delayed copies to same destinations as single-threaded copies", _duplicateDestinationDelayedJobs.Count);
+                foreach (CopyJob job in _duplicateDestinationDelayedJobs)
+                {
+                    job.DestFile.Refresh();
+                    CopyFileImpl(job.SourceFile, job.DestFile, job.Metadata);
+                }
+            }
+
+            Log.LogMessage(
+                "Copied {0} files{1}",
+                _numFilesCopied,
+                _numFilesSkipped == 0 ? string.Empty : $", skipped {_numFilesSkipped}",
+                _numErrors == 0 ? string.Empty : $", {_numErrors} errors",
+                _duplicateDestinationDelayedJobs.Count == 0 ? string.Empty : $", {_duplicateDestinationDelayedJobs.Count} copies to same destination delayed to run single-threaded");
             return !Log.HasLoggedErrors;
         }
 
-        private void CopyFile(FileInfo sourceFile, FileInfo destFile, bool createDirs, RobocopyMetadata metadata)
+        private static int GetMsBuildCopyTaskParallelism()
         {
-            if (createDirs)
+            // Use the MSBuild Copy task override parallelism setting if present.
+            // https://github.com/dotnet/msbuild/blob/1ff019aaa7cc17f22990548bb19498dfbbdebaec/src/Framework/Traits.cs#L83
+            string? par = Environment.GetEnvironmentVariable("MSBUILDCOPYTASKPARALLELISM");
+            if (string.IsNullOrEmpty(par) || !int.TryParse(par, out int parallelism))
+            {
+                return DefaultCopyParallelism;
+            }
+
+            return parallelism;
+        }
+
+        private void CopyFile(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata)
+        {
+            // When multiple copies are targeted to the same destination, copy the 2nd and subsequent copies single-threaded.
+            // Note this will not detect the same destination via symlinks or junctions.
+            if (_destinationPathsStarted.Add(destFile.FullName))
+            {
+                if (_filesCopied.Add(new CopyFileDedupKey(sourceFile.FullName, destFile.FullName)))
+                {
+                    _copyFileBlock.Post(new CopyJob(sourceFile, destFile, metadata));
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Skipped {0} to {1} as duplicate copy", sourceFile.FullName, destFile.FullName);
+                }
+            }
+            else if (!_filesCopied.Contains(new CopyFileDedupKey(sourceFile.FullName, destFile.FullName)))
+            {
+                Log.LogMessage("Delaying {0} to {1} as duplicate destination", sourceFile.FullName, destFile.FullName);
+                _duplicateDestinationDelayedJobs.Add(new CopyJob(sourceFile, destFile, metadata));
+            }
+            else
+            {
+                Log.LogMessage(MessageImportance.Low, "Skipped {0} to {1} as duplicate copy", sourceFile.FullName, destFile.FullName);
+            }
+        }
+
+        private void CopyFileImpl(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata)
+        {
+            if (destFile.DirectoryName is not null)
             {
                 CreateDirectoryWithRetries(destFile.DirectoryName);
             }
+
+            string sourcePath = sourceFile.FullName;
+            string destPath = destFile.FullName;
 
             for (int retry = 0; retry <= RetryCount; ++retry)
             {
@@ -60,21 +181,50 @@ namespace Microsoft.Build.Artifacts.Tasks
                 {
                     if (metadata.ShouldCopy(FileSystem, sourceFile, destFile))
                     {
-                        destFile = FileSystem.CopyFile(sourceFile, destFile.FullName, true);
+                        bool cowLinked = false;
+                        if (!DisableCopyOnWrite)
+                        {
+                            // Fast-path: We're on a CoW capable filesystem.
+                            // On any problem fall back to real copy.
+                            try
+                            {
+                                cowLinked = FileSystem.TryCloneFile(sourceFile, destFile);
+                                if (cowLinked)
+                                {
+                                    destFile.Refresh();
+                                }
+                            }
+                            catch (Win32Exception win32Ex) when (win32Ex.NativeErrorCode == ErrorSharingViolation)
+                            {
+                                Log.LogMessage("Sharing violation creating copy-on-write link from {0} to {1}, retrying with copy", sourcePath, destPath);
+                            }
+                            catch (Exception ex)
+                            {
+                                Log.LogMessage("Exception creating copy-on-write link from {0} to {1}, retrying with copy: {2}", sourcePath, destPath, ex);
+                            }
+                        }
+
+                        if (!cowLinked)
+                        {
+                            destFile = FileSystem.CopyFile(sourceFile, destPath, overwrite: true);
+                        }
+
                         destFile.Attributes = FileAttributes.Normal;
-                        destFile.LastWriteTime = sourceFile.LastWriteTime;
-                        Log.LogMessage(MessageImportance.Low, "Copied {0} to {1}", sourceFile.FullName, destFile.FullName);
+                        destFile.LastWriteTimeUtc = sourceFile.LastWriteTimeUtc;
+                        Log.LogMessage("{0} {1} to {2}", cowLinked ? "Created copy-on-write link" : "Copied", sourcePath, destPath);
+                        Interlocked.Increment(ref _numFilesCopied);
                     }
                     else
                     {
                         Log.LogMessage(MessageImportance.Low, "Skipped copying {0} to {1}", sourceFile.FullName, destFile.FullName);
+                        Interlocked.Increment(ref _numFilesSkipped);
                     }
 
                     break;
                 }
                 catch (IOException e)
                 {
-                    LogCopyFailureAndSleep(retry, "Failed to copy {0} to {1}. {2}", sourceFile.FullName, destFile.FullName, e.Message);
+                    LogCopyFailureAndSleep(retry, "Failed to copy {0} to {1}. {2}", sourcePath, destPath, e.Message);
                 }
             }
         }
@@ -101,46 +251,53 @@ namespace Microsoft.Build.Artifacts.Tasks
 
         private void CopyItems(IList<RobocopyMetadata> items, DirectoryInfo source)
         {
+            string sourceDir = source.FullName;
+
             foreach (RobocopyMetadata item in items)
             {
-                bool createDirs = true;
                 foreach (string file in item.FileMatches)
                 {
-                    FileInfo sourceFile = new FileInfo(Path.Combine(source.FullName, file));
+                    // Break down symlinks/junctions to their real paths to avoid duplicate copies.
+                    string sourcePath = Path.Combine(sourceDir, file);
+                    FileInfo sourceFile = new FileInfo(sourcePath);
                     if (Verify(sourceFile, true, item.VerifyExists))
                     {
-                        foreach (string destination in item.DestinationFolders)
+                        foreach (string destDir in item.DestinationFolders)
                         {
-                            FileInfo destFile = new FileInfo(Path.Combine(destination, file));
-                            if (Verify(destFile, false, false))
+                            string destPath = Path.Combine(destDir, file);
+                            FileInfo destFile = new FileInfo(destPath);
+                            if (Verify(destFile, shouldExist: false, false))
                             {
-                                CopyFile(sourceFile, destFile, createDirs, item);
+                                CopyFile(sourceFile, destFile, item);
                             }
                         }
-
-                        // only try to create the dirs for the first set of files
-                        createDirs = false;
                     }
                 }
             }
         }
 
-        private void CopySearch(IList<RobocopyMetadata> bucket, bool isRecursive, string match, DirectoryInfo source, string subDirectory)
+        private void CopySearch(IList<RobocopyMetadata> bucket, bool isRecursive, string match, DirectoryInfo source, string? subDirectory)
         {
+            string sourceDir = source.FullName;
+
             bool hasSubDirectory = !string.IsNullOrEmpty(subDirectory);
+
             foreach (FileInfo sourceFile in FileSystem.EnumerateFiles(source, match))
             {
                 foreach (RobocopyMetadata item in bucket)
                 {
-                    if (item.IsMatch(sourceFile.Name, subDirectory, isFile: true))
+                    string fileName = sourceFile.Name;
+                    if (item.IsMatch(fileName, subDirectory, isFile: true))
                     {
-                        foreach (string destination in item.DestinationFolders)
+                        foreach (string destinationDir in item.DestinationFolders)
                         {
-                            string fullDest = hasSubDirectory ? Path.Combine(destination, subDirectory) : destination;
-                            FileInfo destFile = new FileInfo(Path.Combine(fullDest, sourceFile.Name));
-
-                            Verify(destFile, false, false);
-                            CopyFile(sourceFile, destFile, true, item);
+                            string destDir = hasSubDirectory ? Path.Combine(destinationDir, subDirectory!) : destinationDir;
+                            string destPath = Path.Combine(destDir, fileName);
+                            FileInfo destFile = new FileInfo(destPath);
+                            if (Verify(destFile, shouldExist: false, false))
+                            {
+                                CopyFile(sourceFile, destFile, item);
+                            }
                         }
                     }
                 }
@@ -152,7 +309,7 @@ namespace Microsoft.Build.Artifacts.Tasks
                 foreach (DirectoryInfo childSource in FileSystem.EnumerateDirectories(source))
                 {
                     // per dir we need to re-items for those items excluding a specific dir
-                    string childSubDirectory = hasSubDirectory ? Path.Combine(subDirectory, childSource.Name) : childSource.Name;
+                    string childSubDirectory = hasSubDirectory ? Path.Combine(subDirectory!, childSource.Name) : childSource.Name;
                     IList<RobocopyMetadata> subBucket = new List<RobocopyMetadata>();
                     foreach (RobocopyMetadata item in bucket)
                     {
@@ -174,13 +331,23 @@ namespace Microsoft.Build.Artifacts.Tasks
             {
                 try
                 {
-                    FileSystem.CreateDirectory(directory);
-
+                    // Minimize filesystem calls for directory creation. AddOrUpdate must be used instead of GetOrAdd for this pattern to work.
+                    _dirsCreated.AddOrUpdate(directory, d =>
+                        {
+                            // Create directory before exiting add lock -
+                            // this logic may be executed multiple times on different threads
+                            // but must create the directory before exiting.
+                            FileSystem.CreateDirectory(d);
+                            return true;
+                        },
+                        #pragma warning disable SA1117
+                        (_, f) => f);
+                        #pragma warning restore SA1117
                     break;
                 }
                 catch (IOException)
                 {
-                    /* ignore failures - we'll catch them later on copy */
+                    // Ignore failures - we'll catch them later on copy.
                     Sleep(TimeSpan.FromMilliseconds(200));
                 }
             }
@@ -191,7 +358,7 @@ namespace Microsoft.Build.Artifacts.Tasks
             IList<RobocopyMetadata> allSources = new List<RobocopyMetadata>();
             IList<IList<RobocopyMetadata>> allBuckets = new List<IList<RobocopyMetadata>>();
 
-            foreach (ITaskItem item in Sources ?? Enumerable.Empty<ITaskItem>())
+            foreach (ITaskItem item in Sources)
             {
                 if (RobocopyMetadata.TryParse(item, Log, FileSystem.DirectoryExists, out RobocopyMetadata metadata))
                 {
@@ -222,7 +389,7 @@ namespace Microsoft.Build.Artifacts.Tasks
                 for (int i = 0; i < allSources.Count; ++i)
                 {
                     RobocopyMetadata item = allSources[i];
-                    if (string.Equals(item.SourceFolder, first.SourceFolder, StringComparison.OrdinalIgnoreCase) &&
+                    if (string.Equals(item.SourceFolder, first.SourceFolder, Artifacts.FileSystem.PathComparison) &&
                         item.HasWildcardMatches == first.HasWildcardMatches &&
                         item.IsRecursive == first.IsRecursive)
                     {
@@ -254,6 +421,8 @@ namespace Microsoft.Build.Artifacts.Tasks
 
         private void LogCopyFailureAndSleep(int attempt, string message, params object[] args)
         {
+            Interlocked.Increment(ref _numErrors);
+
             if (attempt > 0)
             {
                 message += $" :  retry {attempt}/{RetryCount}";
@@ -288,6 +457,52 @@ namespace Microsoft.Build.Artifacts.Tasks
             }
 
             return false;
+        }
+
+        // Internal for unit testing.
+        internal readonly struct CopyFileDedupKey
+        {
+            private readonly string _sourcePath;
+            private readonly string _destPath;
+
+            public CopyFileDedupKey(string source, string dest)
+            {
+                _sourcePath = source;
+                _destPath = dest;
+            }
+
+            public static Comparer ComparerInstance { get; } = new ();
+
+            public sealed class Comparer : IEqualityComparer<CopyFileDedupKey>
+            {
+                public bool Equals(CopyFileDedupKey x, CopyFileDedupKey y)
+                {
+                    return x._sourcePath.Equals(y._sourcePath, Artifacts.FileSystem.PathComparison) &&
+                           x._destPath.Equals(y._destPath, Artifacts.FileSystem.PathComparison);
+                }
+
+                public int GetHashCode(CopyFileDedupKey obj)
+                {
+                    return Artifacts.FileSystem.PathComparer.GetHashCode(obj._destPath) ^
+                           Artifacts.FileSystem.PathComparer.GetHashCode(obj._sourcePath);
+                }
+            }
+        }
+
+        private sealed class CopyJob
+        {
+            public CopyJob(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata)
+            {
+                SourceFile = sourceFile;
+                DestFile = destFile;
+                Metadata = metadata;
+            }
+
+            public FileInfo SourceFile { get; }
+
+            public FileInfo DestFile { get; }
+
+            public RobocopyMetadata Metadata { get; }
         }
     }
 }

--- a/src/Artifacts/Tasks/RobocopyMetadata.cs
+++ b/src/Artifacts/Tasks/RobocopyMetadata.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Build.Artifacts.Tasks
 
         public bool AlwaysCopy { get; private set; }
 
-        public List<string> DestinationFolders { get; } = new List<string>();
+        public List<string> DestinationFolders { get; } = new ();
 
         public string[] DirExcludes { get; private set; }
 
@@ -103,7 +103,7 @@ namespace Microsoft.Build.Artifacts.Tasks
             {
                 if (destination.StartsWith(@"\") && !destination.StartsWith(@"\\"))
                 {
-                    log.LogError("The specified destination \"{0}\" cannot start with '{1}'", destination, Path.DirectorySeparatorChar);
+                    log.LogError("The specified destination \"{0}\" cannot start with '\\'", destination);
                     return false;
                 }
 
@@ -190,8 +190,8 @@ namespace Microsoft.Build.Artifacts.Tasks
                     foreach (string match in FileMatches)
                     {
                         bool isRooted = Path.IsPathRooted(match);
-                        if (isRooted && string.Equals(match, rootedItem, StringComparison.OrdinalIgnoreCase) ||
-                           !isRooted && string.Equals(match, item, StringComparison.OrdinalIgnoreCase))
+                        if (isRooted && string.Equals(match, rootedItem, FileSystem.PathComparison) ||
+                           !isRooted && string.Equals(match, item, FileSystem.PathComparison))
                         {
                             isMatch = true;
                             break;
@@ -215,8 +215,8 @@ namespace Microsoft.Build.Artifacts.Tasks
                 foreach (string exclude in FileExcludes)
                 {
                     bool isRooted = Path.IsPathRooted(exclude);
-                    if (isRooted && rootedItem.Equals(exclude, StringComparison.OrdinalIgnoreCase) ||
-                       !isRooted && item.Equals(exclude, StringComparison.OrdinalIgnoreCase))
+                    if (isRooted && rootedItem.Equals(exclude, FileSystem.PathComparison) ||
+                       !isRooted && item.Equals(exclude, FileSystem.PathComparison))
                     {
                         return false;
                     }
@@ -243,7 +243,7 @@ namespace Microsoft.Build.Artifacts.Tasks
                 foreach (string exclude in DirExcludes)
                 {
                     // Exclude directories with matching sub-directory
-                    if (rootedItem.EndsWith(exclude, StringComparison.OrdinalIgnoreCase))
+                    if (rootedItem.EndsWith(exclude, FileSystem.PathComparison))
                     {
                         return false;
                     }
@@ -279,7 +279,7 @@ namespace Microsoft.Build.Artifacts.Tasks
 
         private string DumpString(string[] noWild, Regex[] wild)
         {
-            StringBuilder builder = new StringBuilder();
+            StringBuilder builder = new StringBuilder(128);
             if (noWild != null)
             {
                 foreach (string item in noWild)

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -9,7 +9,6 @@
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-
   <UsingTask TaskName="Robocopy"
              AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net46\Microsoft.Build.Artifacts.dll'))"
              Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(MSBuildVersion)' &lt; '16.0'" />
@@ -40,6 +39,7 @@
       RetryWait="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryDelayMilliseconds), $(CopyRetryDelayMilliseconds)))"
       ShowDiagnosticTrace="$(ArtifactsShowDiagnostics)"
       ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(ArtifactsShowErrorOnRetry), 'true'))"
+      DisableCopyOnWrite="$([MSBuild]::ValueOrDefault($(DisableCopyOnWrite), 'false'))"
       Sources="@(Artifact)"
       Condition="@(Artifact->Count()) > 0" />
   </Target>
@@ -53,6 +53,7 @@
       RetryWait="$([MSBuild]::ValueOrDefault($(RobocopyRetryWait), $(CopyRetryDelayMilliseconds)))"
       ShowDiagnosticTrace="$(RobocopyShowDiagnosticTrace)"
       ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(RobocopyShowErrorOnRetry), 'true'))"
+      DisableCopyOnWrite="$([MSBuild]::ValueOrDefault($(DisableCopyOnWrite), 'false'))"
       Sources="@(Robocopy)"
       Condition="@(Robocopy->Count()) > 0"/>
   </Target>

--- a/src/Artifacts/version.json
+++ b/src/Artifacts/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "4.2"
+  "version": "5.0"
 }

--- a/src/CopyOnWrite/Sdk/Sdk.targets
+++ b/src/CopyOnWrite/Sdk/Sdk.targets
@@ -2,5 +2,5 @@
     <UsingTask
         TaskName="Copy"
         AssemblyFile="$(MSBuildThisFileDirectory)..\build\netstandard2.0\Microsoft.Build.CopyOnWrite.dll"
-        Condition="'$(EnableCopyOnWrite)' != 'false'"/>
+        Condition=" '$(DisableCopyOnWrite)' != 'true' AND '$(DisableCopyOnWrite)' != '1' " />
 </Project>

--- a/src/CopyOnWrite/Sdk/Sdk.targets
+++ b/src/CopyOnWrite/Sdk/Sdk.targets
@@ -2,5 +2,5 @@
     <UsingTask
         TaskName="Copy"
         AssemblyFile="$(MSBuildThisFileDirectory)..\build\netstandard2.0\Microsoft.Build.CopyOnWrite.dll"
-        Condition="'$(EnableCopyOnWriteWin)' != 'false'"/>
+        Condition="'$(EnableCopyOnWrite)' != 'false'"/>
 </Project>

--- a/src/CopyOnWrite/build/Microsoft.Build.CopyOnWrite.targets
+++ b/src/CopyOnWrite/build/Microsoft.Build.CopyOnWrite.targets
@@ -1,6 +1,6 @@
 ﻿<Project>
-    <UsingTask
+	<UsingTask
         TaskName="Copy"
         AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.CopyOnWrite.dll"
-        Condition="'$(EnableCopyOnWriteWin)' != 'false'"/>
+        Condition=" '$(DisableCopyOnWrite)' != 'true' AND '$(DisableCopyOnWrite)' != '1' " />
 </Project>


### PR DESCRIPTION
- Use the CopyOnWrite library and an action block to greatly speed up artifact copies. Use parallelism settings similar to those in the Microsoft.Build.CopyOnWrite SDK and allow turning off CoW linking with a task setting.
- Fix an overcopying bug where the same source:destination pair would be copied multiple times.
- Don't copy files onto themselves (seen in occasional cases).
- Linearize same-destination copies from different sources.
- Update major version of Artifacts.
- Unify on 'DisableCopyOnWrite' property for Copy and Artifacts
- Migrate CoW SDK Copy task to use CoW package for clone file compat checks.
- Fix possibility of under-copying different-cased files/paths on Linux by varying path comparers by OS. NOTE: Did not update the CoW Copy task, and MSBuild itself seems to use IgnoreCase in most cases. Need feedback here.
