### PR TITLE
Fix error on missing CoW assembly in Artifacts

### DIFF
--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -4,6 +4,7 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="CopyOnWrite" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSBuild.ProjectCreation" />
     <PackageReference Include="Newtonsoft.Json" />

--- a/src/Artifacts/Microsoft.Build.Artifacts.csproj
+++ b/src/Artifacts/Microsoft.Build.Artifacts.csproj
@@ -10,9 +10,10 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GetMyPackageFiles</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CopyOnWrite" Condition="'$(TargetFramework)' != 'net46'" />
+    <PackageReference Include="CopyOnWrite" GeneratePathProperty="True" PrivateAssets="All" Condition="'$(TargetFramework)' != 'net46'" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
   </ItemGroup>
@@ -27,6 +28,18 @@
     <FilesToSign Include="$(TargetPath)" Authenticode="Microsoft400" StrongName="StrongName" />
   </ItemGroup>
   <Target Name="SignNuGetPackage" />
+  <Target Name="GetMyPackageFiles" DependsOnTargets="ResolveProjectReferences" Condition=" '$(TargetFramework)' != 'net46' ">
+    <PropertyGroup>
+      <CoWFramework Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netstandard2.0' ">netstandard2.0</CoWFramework>
+      <CoWFramework Condition=" '$(TargetFramework)' == 'net6.0' ">net6.0</CoWFramework>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(PkgCopyOnWrite)\lib\$(CoWFramework)\CopyOnWrite.dll"
+                              Pack="true"
+                              PackagePath="\build\$(TargetFramework)" />
+    </ItemGroup>
+  </Target>
   <Target Name="CopyArtifacts"
           AfterTargets="Pack"
           DependsOnTargets="SignNuGetPackage"

--- a/src/Artifacts/version.json
+++ b/src/Artifacts/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "5.0"
+  "version": "5.0.1"
 }

--- a/src/Artifacts/version.json
+++ b/src/Artifacts/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "5.0.1"
+  "version": "5.0"
 }


### PR DESCRIPTION
Declare the CoW package private and explicitly copy its assembly alongside the Artifacts assembly for net472 and netstandard2.0. For #463 