### PR TITLE
Remove old TFMs from Artifacts SDK

### DIFF
--- a/src/Artifacts/Microsoft.Build.Artifacts.csproj
+++ b/src/Artifacts/Microsoft.Build.Artifacts.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net46;net472;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Build logic for staging artifacts from build outputs.</Description>
@@ -10,10 +10,9 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);GetMyPackageFiles</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="CopyOnWrite" GeneratePathProperty="True" PrivateAssets="All" Condition="'$(TargetFramework)' != 'net46'" />
+    <PackageReference Include="CopyOnWrite" GeneratePathProperty="True" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="Runtime" PrivateAssets="All" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" />
   </ItemGroup>
@@ -28,18 +27,6 @@
     <FilesToSign Include="$(TargetPath)" Authenticode="Microsoft400" StrongName="StrongName" />
   </ItemGroup>
   <Target Name="SignNuGetPackage" />
-  <Target Name="GetMyPackageFiles" DependsOnTargets="ResolveProjectReferences" Condition=" '$(TargetFramework)' != 'net46' ">
-    <PropertyGroup>
-      <CoWFramework Condition=" '$(TargetFramework)' == 'net472' or '$(TargetFramework)' == 'netstandard2.0' ">netstandard2.0</CoWFramework>
-      <CoWFramework Condition=" '$(TargetFramework)' == 'net6.0' ">net6.0</CoWFramework>
-    </PropertyGroup>
-
-    <ItemGroup>
-      <TfmSpecificPackageFile Include="$(PkgCopyOnWrite)\lib\$(CoWFramework)\CopyOnWrite.dll"
-                              Pack="true"
-                              PackagePath="\build\$(TargetFramework)" />
-    </ItemGroup>
-  </Target>
   <Target Name="CopyArtifacts"
           AfterTargets="Pack"
           DependsOnTargets="SignNuGetPackage"
@@ -52,5 +39,12 @@
           DestinationFiles="@(Artifact->'$(ArtifactsPath)%(RecursiveDir)%(Filename)%(Extension)')"
           SkipUnchangedFiles="$(SkipCopyUnchangedFiles)"
           OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)" />
+  </Target>
+
+  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage" BeforeTargets="_GetBuildOutputFilesWithTfm" DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))" TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+    </ItemGroup>
   </Target>
 </Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -10,14 +10,7 @@
   </PropertyGroup>
 
   <UsingTask TaskName="Robocopy"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net46\Microsoft.Build.Artifacts.dll'))"
-             Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(MSBuildVersion)' &lt; '16.0'" />
-  <UsingTask TaskName="Robocopy"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)net472\Microsoft.Build.Artifacts.dll'))"
-             Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(MSBuildVersion)' &gt;= '16.0'" />
-  <UsingTask TaskName="Robocopy"
-             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.Artifacts.dll'))"
-             Condition="'$(MSBuildRuntimeType)' == 'Core'" />
+             AssemblyFile="$([MSBuild]::ValueOrDefault('$(ArtifactsTaskAssembly)', '$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.Artifacts.dll'))" />
 
   <ItemDefinitionGroup>
     <Robocopy>

--- a/src/Artifacts/version.json
+++ b/src/Artifacts/version.json
@@ -1,4 +1,4 @@
 ﻿{
   "inherit": true,
-  "version": "5.0"
+  "version": "6.0"
 }


### PR DESCRIPTION
Fixes an issue with copy on write changes and the wrong dll getting used (`net472` dll would call into code that was disabled by ifdef). Turned out to be easier to just remove the legacy TFM and only target `netstandard2.0`.