### PR TITLE
Stop testing with .NET 8

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <MicroBuild_NuPkgSigningEnabled Condition="'$(SignType)' == 'Test'">false</MicroBuild_NuPkgSigningEnabled>
     <NoWarn Condition="'$(IsTestProject)' == 'true'">$(NoWarn);SA1600</NoWarn>
+    <ShadeAssemblies Condition="'$(Configuration)' == 'Release'">false</ShadeAssemblies>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SignType)' == 'Test'">

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -74,6 +74,7 @@ stages:
       inputs:
         projects: 'MSBuildSdks.sln'
         msbuildArgs: '$(MSBuildArgs)'
+        msbuildArchitecture: 'x64'
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifacts'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,7 +7,6 @@ variables:
   BuildPlatform: 'Any CPU'
   DotNet6Version: '6.x'
   DotNet7Version: '7.x'
-  DotNet8Version: '8.x'
   MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Test'
 
@@ -46,12 +45,6 @@ jobs:
     inputs:
       version: '$(DotNet7Version)'
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET $(DotNet8Version)'
-    inputs:
-      version: '$(DotNet8Version)'
-      includePreviewVersions: true
-
   - task: DotNetCoreCLI@2
     displayName: 'Build Solution'
     inputs:
@@ -82,14 +75,6 @@ jobs:
       testRunTitle: 'Windows .NET 7.0'
     condition: succeededOrFailed()
 
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests (.NET 8.0)'
-    inputs:
-      command: 'test'
-      arguments: '--no-restore --no-build --framework net8.0 /noautorsp'
-      testRunTitle: 'Windows .NET 8.0'
-    condition: succeededOrFailed()
-
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifacts'
     inputs:
@@ -113,12 +98,6 @@ jobs:
     inputs:
       version: '$(DotNet7Version)'
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET $(DotNet8Version)'
-    inputs:
-      version: '$(DotNet8Version)'
-      includePreviewVersions: true
-
   - task: DotNetCoreCLI@2
     displayName: 'dotnet build'
     inputs:
@@ -139,14 +118,6 @@ jobs:
       command: 'test'
       arguments: '--no-restore --no-build --framework net7.0 /noautorsp'
       testRunTitle: 'Linux .NET 7.0'
-    condition: succeededOrFailed()
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests (.NET 8.0)'
-    inputs:
-      command: 'test'
-      arguments: '--no-restore --no-build --framework net8.0 /noautorsp'
-      testRunTitle: 'Linux .NET 8.0'
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
@@ -172,12 +143,6 @@ jobs:
     inputs:
       version: '$(DotNet7Version)'
 
-  - task: UseDotNet@2
-    displayName: 'Install .NET $(DotNet8Version)'
-    inputs:
-      version: '$(DotNet8Version)'
-      includePreviewVersions: true
-
   - task: DotNetCoreCLI@2
     displayName: 'dotnet build'
     inputs:
@@ -198,14 +163,6 @@ jobs:
       command: 'test'
       arguments: '--no-restore --no-build --framework net7.0 /noautorsp'
       testRunTitle: 'MacOS .NET 7.0'
-    condition: succeededOrFailed()
-
-  - task: DotNetCoreCLI@2
-    displayName: 'Run Unit Tests (.NET 8.0)'
-    inputs:
-      command: 'test'
-      arguments: '--no-restore --no-build --framework net8.0 /noautorsp'
-      testRunTitle: 'MacOS .NET 8.0'
     condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1

--- a/global.json
+++ b/global.json
@@ -1,7 +1,8 @@
 {
   "sdk": {
-    "version": "6.0.100",
-    "rollForward": "latestMajor"
+    "version": "7.0.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": true
   },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.0"

--- a/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
+++ b/src/Artifacts.UnitTests/Microsoft.Build.Artifacts.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AssemblyShader" />

--- a/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
+++ b/src/CentralPackageVersions.UnitTests/Microsoft.Build.CentralPackageVersions.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/CopyOnWrite.UnitTests/Microsoft.Build.CopyOnWrite.UnitTests.csproj
+++ b/src/CopyOnWrite.UnitTests/Microsoft.Build.CopyOnWrite.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
     <Nullable>Enable</Nullable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
+++ b/src/NoTargets.UnitTests/Microsoft.Build.NoTargets.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AssemblyShader" />

--- a/src/NoTargets.UnitTests/NoTargetsTests.cs
+++ b/src/NoTargets.UnitTests/NoTargetsTests.cs
@@ -93,8 +93,6 @@ namespace Microsoft.Build.NoTargets.UnitTests
                     targetFramework: "net7.0")
 #elif NET6_0
                     targetFramework: "net6.0")
-#elif NET8_0
-                    targetFramework: "net8.0")
 #endif
                 .Save();
 

--- a/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
+++ b/src/Traversal.UnitTests/Microsoft.Build.Traversal.UnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AssemblyShader" />


### PR DESCRIPTION
CI machines only have Visual Studio 17.7 which cannot target .NET 8