### PR TITLE
Fix for self-copy deleting the source file in CoW copying

### DIFF
--- a/src/Artifacts/Tasks/RobocopyMetadata.cs
+++ b/src/Artifacts/Tasks/RobocopyMetadata.cs
@@ -264,6 +264,13 @@ namespace Microsoft.Build.Artifacts.Tasks
 
         public bool ShouldCopy(IFileSystem fileSystem, FileInfo source, FileInfo dest)
         {
+            if (string.Equals(source.FullName, dest.FullName, FileSystem.PathComparison))
+            {
+                // Self-copy makes no sense.
+                // TODO: This does not handle the case where the file is the same via different directory symlinks/junctions.
+                return false;
+            }
+
             if (AlwaysCopy || !fileSystem.FileExists(dest))
             {
                 return true;

--- a/src/CopyOnWrite/MSBuild/FileState.cs
+++ b/src/CopyOnWrite/MSBuild/FileState.cs
@@ -43,6 +43,11 @@ namespace Microsoft.Build.Tasks
             private readonly string _filename;
 
             /// <summary>
+            /// The fully resolved path (via Path.GetFullPath).
+            /// </summary>
+            public readonly string FullPath;
+
+            /// <summary>
             /// Set to true if file or directory exists
             /// </summary>
             public readonly bool Exists;
@@ -85,6 +90,7 @@ namespace Microsoft.Build.Tasks
                 LastWriteTimeUtc = new DateTime(1601, 1, 1);
 
                 _filename = FileUtilities.AttemptToShortenPath(filename); // This is no-op unless the path actually is too long
+                FullPath = FileUtilities.NormalizePath(_filename);
 
                 int oldMode = 0;
 
@@ -304,9 +310,18 @@ namespace Microsoft.Build.Tasks
 
         /// <summary>
         /// Name of the file as it was passed in.
-        /// Not normalized.
+        /// Not normalized unless the original path was too long.
         /// </summary>
         internal string Name => _filename;
+
+        internal string FullPath
+        {
+            get
+            {
+                _data.Value.ThrowException();
+                return _data.Value.FullPath;
+            }
+        }
 
         /// <summary>
         /// Use in case the state is known to have changed exogenously.

--- a/src/CopyOnWrite/MSBuild/FileUtilities.cs
+++ b/src/CopyOnWrite/MSBuild/FileUtilities.cs
@@ -3,8 +3,9 @@
 
 using Microsoft.Build.Framework;
 using System;
-using System.Collections.Concurrent;
 using System.IO;
+
+#nullable enable
 
 namespace Microsoft.Build.Shared
 {
@@ -15,8 +16,6 @@ namespace Microsoft.Build.Shared
     /// </summary>
     internal static class FileUtilities
     {
-        private static readonly ConcurrentDictionary<string, bool> FileExistenceCache = new ConcurrentDictionary<string, bool>(StringComparer.OrdinalIgnoreCase);
-
         /// <summary>
         /// Gets the canonicalized full path of the provided path.
         /// Guidance for use: call this on all paths accepted through internal entry
@@ -26,18 +25,8 @@ namespace Microsoft.Build.Shared
         /// </summary>
         internal static string NormalizePath(string path)
         {
-            if (path == null)
-            {
-                throw new ArgumentNullException(nameof(path));
-            }
-
-            string fullPath = GetFullPath(path);
+            string fullPath = Path.GetFullPath(path);
             return FixFilePath(fullPath);
-        }
-
-        private static string GetFullPath(string path)
-        {
-            return Path.GetFullPath(path);
         }
 
         internal static string FixFilePath(string path)

--- a/src/Shared/CopyExceptionHandling.cs
+++ b/src/Shared/CopyExceptionHandling.cs
@@ -36,27 +36,6 @@ internal static class CopyExceptionHandling
     }
 
     /// <summary>
-    /// Compares two paths to see if they refer to the same file, regardless of different path canonicalization
-    /// (e.g. inclusion of '.' or '..' path segments in one or the other path) or symlinks.
-    /// Because of slow performance, this method is intended for use in exception paths for IOException.
-    /// </summary>
-    /// <param name="source">The source file path.</param>
-    /// <param name="destination">The destination file path.</param>
-    /// <returns>True if the paths refer to the same file and a copy operation failure can be ignored.</returns>
-    internal static bool PathsAreIdentical(string source, string destination)
-    {
-        // Collapse path parts like '.' and '..' into a more canonical format.
-        string fullSourcePath = Path.GetFullPath(source);
-        string fullDestinationPath = Path.GetFullPath(destination);
-        if (string.Equals(fullSourcePath, fullDestinationPath, PathComparison))
-        {
-            return true;
-        }
-
-        return FullPathsAreIdentical(fullSourcePath, fullDestinationPath);
-    }
-
-    /// <summary>
     /// Compares two paths to see if they refer to the same file, regardless of symlinks.
     /// Assumes the provided paths have already been canonicalized via Path.GetFullPath().
     /// Because of slow performance, this method is intended for use in exception paths for IOException.
@@ -67,8 +46,8 @@ internal static class CopyExceptionHandling
     internal static bool FullPathsAreIdentical(string source, string destination)
     {
         // Might be copying a file onto itself via symlinks. Compare the resolved paths.
-        string? symlinkResolvedSource = GetRealPathOrNull(source);
-        string? symlinkResolvedDestination = GetRealPathOrNull(destination);
+        string symlinkResolvedSource = GetRealPathOrNull(source) ?? source;
+        string symlinkResolvedDestination = GetRealPathOrNull(destination) ?? destination;
         return string.Equals(symlinkResolvedSource, symlinkResolvedDestination, PathComparison);
     }
 


### PR DESCRIPTION
In CoW Copy and Artifacts, do not copy when the source and destination paths are the same (canonicalized) to avoid deleting the source file when a copy-on-self is happening. This does not handle the case of the same file via differing symlinked paths.