### PR TITLE
Fix for chained copies within the same task session

### DIFF
--- a/src/Artifacts.UnitTests/RobocopyTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyTests.cs
@@ -428,7 +428,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
         [Theory]
         [InlineData("*")]
         [InlineData("*.txt")]
-        public void SingleAndLongChainCopiesAreDelayedAfterFirstPartOfChain(string match)
+        public void SingleAndLongChainCopiesParallelCopyOriginalSourceFile(string match)
         {
             DirectoryInfo source = CreateFiles(
                 "source",

--- a/src/Artifacts/FileSystem.cs
+++ b/src/Artifacts/FileSystem.cs
@@ -8,6 +8,7 @@ using Microsoft.CopyOnWrite;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text.RegularExpressions;
 
 #nullable enable
 
@@ -34,6 +35,11 @@ namespace Microsoft.Build.Artifacts
         /// Gets the OS-specific path comparer.
         /// </summary>
         public static StringComparer PathComparer { get; } = IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+        /// <summary>
+        /// Gets the OS-specific Regex options for path regex matching.
+        /// </summary>
+        public static RegexOptions PathRegexOptions { get; } = IsWindows ? RegexOptions.IgnoreCase : RegexOptions.None;
 
         /// <summary>
         /// Gets a singleton instance of this class.

--- a/src/Artifacts/Tasks/Robocopy.cs
+++ b/src/Artifacts/Tasks/Robocopy.cs
@@ -113,7 +113,7 @@ namespace Microsoft.Build.Artifacts.Tasks
             // Remaining jobs must run single-threaded in order to ensure ordering of filesystem changes.
             if (_duplicateDestinationDelayedJobs.Count > 0)
             {
-                Log.LogMessage("Finishing {0} delayed copies to same destinations as as single-threaded", _duplicateDestinationDelayedJobs.Count);
+                Log.LogMessage($"Finishing {_duplicateDestinationDelayedJobs.Count} delayed copies to same destinations as single-threaded copies");
                 foreach (CopyJob job in _duplicateDestinationDelayedJobs)
                 {
                     job.DestFile.Refresh();

--- a/src/Artifacts/Tasks/Robocopy.cs
+++ b/src/Artifacts/Tasks/Robocopy.cs
@@ -130,7 +130,6 @@ namespace Microsoft.Build.Artifacts.Tasks
             return !Log.HasLoggedErrors;
         }
 
-
         /// <summary>
         /// Converts a wildcard file pattern to a regular expression string.
         /// </summary>

--- a/src/Artifacts/Tasks/Robocopy.cs
+++ b/src/Artifacts/Tasks/Robocopy.cs
@@ -11,6 +11,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks.Dataflow;
 
@@ -31,10 +32,9 @@ namespace Microsoft.Build.Artifacts.Tasks
         private static readonly ExecutionDataflowBlockOptions ActionBlockOptions = new () { MaxDegreeOfParallelism = MsBuildCopyParallelism, EnsureOrdered = MsBuildCopyParallelism == 1 };
 
         private readonly ConcurrentDictionary<string, bool> _dirsCreated = new (Artifacts.FileSystem.PathComparer);
-        private readonly HashSet<string> _destinationPathsStarted = new (Artifacts.FileSystem.PathComparer);  // Destination paths that were dispatched to copy. Extra copies to the same destination are copied single-threaded in a second wave.
         private readonly List<CopyJob> _duplicateDestinationDelayedJobs = new ();  // Jobs that were delayed because they were to a destination path that was already dispatched to copy.
+        private readonly ConcurrentDictionary<string, Dictionary<string, FileInfo>> _destinationDirectoryFilesCopying = new (concurrencyLevel: 1, capacity: 31, Artifacts.FileSystem.PathComparer);  // Map for destination directories to track files being copied there in parallel portion of copy. Concurrent dictionaries to get TryAdd(), GetOrAdd().
         private readonly ActionBlock<CopyJob> _copyFileBlock;
-        private readonly HashSet<CopyFileDedupKey> _filesCopied = new (CopyFileDedupKey.ComparerInstance);
         private TimeSpan _retryWaitInMilliseconds = TimeSpan.Zero;
         private int _numFilesCopied;
         private int _numFilesSkipped;
@@ -46,7 +46,7 @@ namespace Microsoft.Build.Artifacts.Tasks
             {
                 // Break from synchronous thread context of caller to get onto global thread pool thread for synchronous copy operations.
                 await System.Threading.Tasks.Task.Yield();
-                CopyFileImpl(job.SourceFile, job.DestFile, job.Metadata);
+                CopyFileImpl(job.SourceFile, job.DestFile, job.Metadata, job.ReplacementSourceFile);
             }, ActionBlockOptions);
         }
 
@@ -104,16 +104,18 @@ namespace Microsoft.Build.Artifacts.Tasks
                 CopyItems(bucket);
             }
 
+            // Complete the parallel part of the copy job.
             _copyFileBlock.Complete();
             _copyFileBlock.Completion.GetAwaiter().GetResult();
 
+            // Remaining jobs must run single-threaded in order to ensure ordering of filesystem changes.
             if (_duplicateDestinationDelayedJobs.Count > 0)
             {
-                Log.LogMessage("Finishing {0} delayed copies to same destinations as single-threaded copies", _duplicateDestinationDelayedJobs.Count);
+                Log.LogMessage("Finishing {0} delayed copies to same destinations as as single-threaded", _duplicateDestinationDelayedJobs.Count);
                 foreach (CopyJob job in _duplicateDestinationDelayedJobs)
                 {
                     job.DestFile.Refresh();
-                    CopyFileImpl(job.SourceFile, job.DestFile, job.Metadata);
+                    CopyFileImpl(job.SourceFile, job.DestFile, job.Metadata, job.ReplacementSourceFile);
                 }
             }
 
@@ -139,47 +141,88 @@ namespace Microsoft.Build.Artifacts.Tasks
             return parallelism;
         }
 
+        /// <summary>
+        /// Converts a wildcard file pattern to a regular expression.
+        /// </summary>
+        private static Regex WildcardToRegex(string pattern)
+        {
+            pattern = Regex.Escape(pattern);
+            pattern = pattern.Replace("\\*", ".*");
+            pattern = pattern.Replace("\\?", ".?");
+            return new Regex(pattern, Artifacts.FileSystem.PathRegexOptions);
+        }
+
+        /// <summary>
+        /// Intended to be called during the parallel portion of the copy job. It may kick work out to the single-threaded portion of the job.
+        /// During single-threaded post-processing use <see cref="CopyFileImpl"/>
+        /// </summary>
         private void CopyFile(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata)
         {
-            // When multiple copies are targeted to the same destination, copy the 2nd and subsequent copies single-threaded.
-            // Note this will not detect the same destination via symlinks or junctions.
-            if (_destinationPathsStarted.Add(destFile.FullName))
+            // There may already be a copy to this source file path underway, indicating a link in a chained copy.
+            // This can be copied in parallel from the original source as long as the destination is unique.
+            string sourceDir = sourceFile.DirectoryName ?? string.Empty;
+            FileInfo? replacementSourceFile;
+            if (_destinationDirectoryFilesCopying.TryGetValue(sourceDir, out Dictionary<string, FileInfo>? copiesUnderwayInSourceDir))
             {
-                if (_filesCopied.Add(new CopyFileDedupKey(sourceFile.FullName, destFile.FullName)))
-                {
-                    _copyFileBlock.Post(new CopyJob(sourceFile, destFile, metadata));
-                }
-                else
-                {
-                    Log.LogMessage(MessageImportance.Low, "Skipped {0} to {1} as duplicate copy", sourceFile.FullName, destFile.FullName);
-                }
-            }
-            else if (!_filesCopied.Contains(new CopyFileDedupKey(sourceFile.FullName, destFile.FullName)))
-            {
-                Log.LogMessage("Delaying copying {0} to {1} as duplicate destination", sourceFile.FullName, destFile.FullName);
-                _duplicateDestinationDelayedJobs.Add(new CopyJob(sourceFile, destFile, metadata));
+                copiesUnderwayInSourceDir.TryGetValue(sourceFile.FullName, out replacementSourceFile);
             }
             else
             {
-                Log.LogMessage(MessageImportance.Low, "Skipped {0} to {1} as duplicate copy", sourceFile.FullName, destFile.FullName);
+                replacementSourceFile = null;
+            }
+
+            CopyFile(sourceFile, destFile, metadata, replacementSourceFile);
+        }
+
+        private void CopyFile(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata, FileInfo? replacementSourceFile)
+        {
+            string destFilePath = destFile.FullName;
+            string destDir = destFile.DirectoryName ?? string.Empty;
+            Dictionary<string, FileInfo> copiesUnderwayInDestDir = _destinationDirectoryFilesCopying.GetOrAdd(
+                destDir,
+                _ => new Dictionary<string, FileInfo>(Artifacts.FileSystem.PathComparer));
+            if (!copiesUnderwayInDestDir.TryGetValue(destFilePath, out FileInfo? sourceFileUnderway))
+            {
+                // No other copies to this destination underway, kick off parallel copy.
+                copiesUnderwayInDestDir[destFilePath] = replacementSourceFile ?? sourceFile;
+                _copyFileBlock.Post(new CopyJob(sourceFile, destFile, metadata, replacementSourceFile));
+            }
+            else
+            {
+                string sourceFilePath = sourceFile.FullName;
+                if (!string.Equals(sourceFilePath, sourceFileUnderway.FullName, Artifacts.FileSystem.PathComparison))
+                {
+                    // When multiple copies are targeted to the same destination, copy the 2nd and subsequent copies single-threaded.
+                    // Note this will not detect the same destination via symlinks or junctions.
+                    Log.LogMessage("Delaying copying {0} to {1} as duplicate destination", sourceFile.FullName, destFilePath);
+                    _duplicateDestinationDelayedJobs.Add(new CopyJob(sourceFile, destFile, metadata, replacementSourceFile));
+                }
+                else
+                {
+                    Log.LogMessage(MessageImportance.Low, "Skipped {0} to {1} as duplicate copy", sourceFilePath, destFilePath);
+                }
             }
         }
 
-        private void CopyFileImpl(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata)
+        /// <summary>
+        /// Used for copying within either a parallel context in the action block or a single-threaded context in the single-threaded phase.
+        /// </summary>
+        private void CopyFileImpl(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata, FileInfo? replacementSourceFile)
         {
             if (destFile.DirectoryName is not null)
             {
                 CreateDirectoryWithRetries(destFile.DirectoryName);
             }
 
-            string sourcePath = sourceFile.FullName;
+            string originalSourcePath = sourceFile.FullName;
             string destPath = destFile.FullName;
 
             for (int retry = 0; retry <= RetryCount; ++retry)
             {
                 try
                 {
-                    if (metadata.ShouldCopy(FileSystem, sourceFile, destFile))
+                    FileInfo sourceToActuallyCopy = replacementSourceFile ?? sourceFile;
+                    if (metadata.ShouldCopy(FileSystem, sourceToActuallyCopy, destFile))
                     {
                         bool cowLinked = false;
                         if (!DisableCopyOnWrite)
@@ -188,7 +231,7 @@ namespace Microsoft.Build.Artifacts.Tasks
                             // On any problem fall back to real copy.
                             try
                             {
-                                cowLinked = FileSystem.TryCloneFile(sourceFile, destFile);
+                                cowLinked = FileSystem.TryCloneFile(sourceToActuallyCopy, destFile);
                                 if (cowLinked)
                                 {
                                     destFile.Refresh();
@@ -196,27 +239,27 @@ namespace Microsoft.Build.Artifacts.Tasks
                             }
                             catch (Win32Exception win32Ex) when (win32Ex.NativeErrorCode == ErrorSharingViolation)
                             {
-                                Log.LogMessage("Sharing violation creating copy-on-write link from {0} to {1}, retrying with copy", sourcePath, destPath);
+                                Log.LogMessage("Sharing violation creating copy-on-write link from {0} to {1}, retrying with copy", originalSourcePath, destPath);
                             }
                             catch (Exception ex)
                             {
-                                Log.LogMessage("Exception creating copy-on-write link from {0} to {1}, retrying with copy: {2}", sourcePath, destPath, ex);
+                                Log.LogMessage("Exception creating copy-on-write link from {0} to {1}, retrying with copy: {2}", originalSourcePath, destPath, ex);
                             }
                         }
 
                         if (!cowLinked)
                         {
-                            destFile = FileSystem.CopyFile(sourceFile, destPath, overwrite: true);
+                            destFile = FileSystem.CopyFile(sourceToActuallyCopy, destPath, overwrite: true);
                         }
 
                         destFile.Attributes = FileAttributes.Normal;
                         destFile.LastWriteTimeUtc = sourceFile.LastWriteTimeUtc;
-                        Log.LogMessage("{0} {1} to {2}", cowLinked ? "Created copy-on-write link" : "Copied", sourcePath, destPath);
+                        Log.LogMessage("{0} {1}{2} to {3}", cowLinked ? "Created copy-on-write link" : "Copied", originalSourcePath, replacementSourceFile is null ? string.Empty : $" (actually {replacementSourceFile.FullName})", destPath);
                         Interlocked.Increment(ref _numFilesCopied);
                     }
                     else
                     {
-                        Log.LogMessage(MessageImportance.Low, "Skipped copying {0} to {1}", sourcePath, destPath);
+                        Log.LogMessage(MessageImportance.Low, "Skipped copying {0} to {1}", originalSourcePath, destPath);
                         Interlocked.Increment(ref _numFilesSkipped);
                     }
 
@@ -225,9 +268,9 @@ namespace Microsoft.Build.Artifacts.Tasks
                 catch (IOException e)
                 {
                     // Avoid issuing an error if the paths are actually to the same file.
-                    if (!CopyExceptionHandling.FullPathsAreIdentical(sourcePath, destPath))
+                    if (!CopyExceptionHandling.FullPathsAreIdentical(originalSourcePath, destPath))
                     {
-                        LogCopyFailureAndSleep(retry, "Failed to copy {0} to {1}. {2}", sourcePath, destPath, e.Message);
+                        LogCopyFailureAndSleep(retry, "Failed to copy {0} to {1}. {2}", originalSourcePath, destPath, e.Message);
                     }
                 }
             }
@@ -244,7 +287,7 @@ namespace Microsoft.Build.Artifacts.Tasks
             if (hasWildcards || isRecursive)
             {
                 string match = GetMatchString(items);
-                CopySearch(items, isRecursive, match, source, null);
+                CopySearch(items, isRecursive, match, matchRegex: null, source, subDirectory: null);
             }
             else
             {
@@ -263,7 +306,8 @@ namespace Microsoft.Build.Artifacts.Tasks
                 {
                     string sourcePath = Path.Combine(sourceDir, file);
                     FileInfo sourceFile = new FileInfo(sourcePath);
-                    if (Verify(sourceFile, item.VerifyExists))
+
+                    if (VerifyExistence(sourceFile, item.VerifyExists))
                     {
                         foreach (string destDir in item.DestinationFolders)
                         {
@@ -276,11 +320,47 @@ namespace Microsoft.Build.Artifacts.Tasks
             }
         }
 
-        private void CopySearch(IList<RobocopyMetadata> bucket, bool isRecursive, string match, DirectoryInfo source, string? subDirectory)
+        /// <summary>
+        /// Enumerates a directory, adding and substituting file entries where a copy is in progress into the directory.
+        /// This allows full copy parallelism - we can copy from the original source file instead of having to wait for the
+        /// first copy to complete.
+        /// </summary>
+        private IEnumerable<(FileInfo, FileInfo?)> EnumerateCurrentAndInProgressFilesInSourceDir(DirectoryInfo sourceDir, string match, Regex matchRegex)
+        {
+            string sourceDirPath = sourceDir.FullName;
+            Dictionary<string, FileInfo> copiesUnderwayIntoDir = _destinationDirectoryFilesCopying.GetOrAdd(
+                sourceDirPath,
+                _ => new Dictionary<string, FileInfo>(Artifacts.FileSystem.PathComparer));
+            HashSet<string> sourceFilesEncountered = new (Artifacts.FileSystem.PathComparer);
+            foreach (FileInfo sourceFile in FileSystem.EnumerateFiles(sourceDir, match))
+            {
+                // If this is a direct match for an in-progress copy, supply the original source to be used as a replacement.
+                string sourceFilePath = sourceFile.FullName;
+                copiesUnderwayIntoDir.TryGetValue(sourceFilePath, out FileInfo? replacementSourceFile);
+                yield return (sourceFile, replacementSourceFile);
+                sourceFilesEncountered.Add(sourceFilePath);
+            }
+
+            // Next enumerate the in-progress copies that match the search but may not have begun to actually copy into the
+            // destination yet because they are in the copy queue.
+            if (copiesUnderwayIntoDir.Count > 0)
+            {
+                foreach (KeyValuePair<string, FileInfo> kvp in copiesUnderwayIntoDir
+                    .Where(kvp => !sourceFilesEncountered.Contains(kvp.Key) &&
+                           matchRegex.IsMatch(Path.GetFileName(kvp.Key))))
+                {
+                    // The FileInfo will show the file missing initially but fulfills the needs of logging the file path.
+                    yield return (new FileInfo(kvp.Key), kvp.Value);
+                }
+            }
+        }
+
+        private void CopySearch(IList<RobocopyMetadata> bucket, bool isRecursive, string match, Regex? matchRegex, DirectoryInfo source, string? subDirectory)
         {
             bool hasSubDirectory = !string.IsNullOrEmpty(subDirectory);
+            matchRegex ??= WildcardToRegex(match);
 
-            foreach (FileInfo sourceFile in FileSystem.EnumerateFiles(source, match))
+            foreach ((FileInfo sourceFile, FileInfo? replacementSourceFile) in EnumerateCurrentAndInProgressFilesInSourceDir(source, match, matchRegex))
             {
                 foreach (RobocopyMetadata item in bucket)
                 {
@@ -292,7 +372,7 @@ namespace Microsoft.Build.Artifacts.Tasks
                             string destDir = hasSubDirectory ? Path.Combine(destinationDir, subDirectory!) : destinationDir;
                             string destPath = Path.Combine(destDir, fileName);
                             FileInfo destFile = new FileInfo(destPath);
-                            CopyFile(sourceFile, destFile, item);
+                            CopyFile(sourceFile, destFile, item, replacementSourceFile);
                         }
                     }
                 }
@@ -314,7 +394,7 @@ namespace Microsoft.Build.Artifacts.Tasks
                         }
                     }
 
-                    CopySearch(subBucket, isRecursive: true, match, childSource, childSubDirectory);
+                    CopySearch(subBucket, isRecursive: true, match, matchRegex, childSource, childSubDirectory);
                 }
             }
         }
@@ -368,11 +448,7 @@ namespace Microsoft.Build.Artifacts.Tasks
                 RobocopyMetadata first = allSources.First();
                 allSources.RemoveAt(0);
 
-                List<RobocopyMetadata> bucket = new List<RobocopyMetadata>
-                {
-                    first,
-                };
-
+                List<RobocopyMetadata> bucket = new List<RobocopyMetadata> { first };
                 allBuckets.Add(bucket);
 
                 if (ShowDiagnosticTrace)
@@ -408,7 +484,7 @@ namespace Microsoft.Build.Artifacts.Tasks
             string match = "*";
             if (bucket.Count == 1)
             {
-                bucket[0].GetMatchString();
+                match = bucket[0].GetMatchString();
             }
 
             return match;
@@ -439,9 +515,17 @@ namespace Microsoft.Build.Artifacts.Tasks
             }
         }
 
-        private bool Verify(FileInfo file, bool verifyExists)
+        private bool VerifyExistence(FileInfo file, bool verifyExists)
         {
             if (FileSystem.FileExists(file))
+            {
+                return true;
+            }
+
+            // Virtual existence: If a copy operation to this source file is already underway,
+            // the copy logic can short-circuit to copy from the original source in parallel.
+            if (_destinationDirectoryFilesCopying.TryGetValue(file.DirectoryName, out Dictionary<string, FileInfo> copiesInProgressToFileDir) &&
+                copiesInProgressToFileDir.ContainsKey(file.FullName))
             {
                 return true;
             }
@@ -454,43 +538,14 @@ namespace Microsoft.Build.Artifacts.Tasks
             return false;
         }
 
-        // Internal for unit testing.
-        internal readonly struct CopyFileDedupKey
-        {
-            private readonly string _sourcePath;
-            private readonly string _destPath;
-
-            public CopyFileDedupKey(string source, string dest)
-            {
-                _sourcePath = source;
-                _destPath = dest;
-            }
-
-            public static Comparer ComparerInstance { get; } = new ();
-
-            public sealed class Comparer : IEqualityComparer<CopyFileDedupKey>
-            {
-                public bool Equals(CopyFileDedupKey x, CopyFileDedupKey y)
-                {
-                    return x._sourcePath.Equals(y._sourcePath, Artifacts.FileSystem.PathComparison) &&
-                           x._destPath.Equals(y._destPath, Artifacts.FileSystem.PathComparison);
-                }
-
-                public int GetHashCode(CopyFileDedupKey obj)
-                {
-                    return Artifacts.FileSystem.PathComparer.GetHashCode(obj._destPath) ^
-                           Artifacts.FileSystem.PathComparer.GetHashCode(obj._sourcePath);
-                }
-            }
-        }
-
         private sealed class CopyJob
         {
-            public CopyJob(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata)
+            public CopyJob(FileInfo sourceFile, FileInfo destFile, RobocopyMetadata metadata, FileInfo? replacementSourceFile)
             {
                 SourceFile = sourceFile;
                 DestFile = destFile;
                 Metadata = metadata;
+                ReplacementSourceFile = replacementSourceFile;
             }
 
             public FileInfo SourceFile { get; }
@@ -498,6 +553,8 @@ namespace Microsoft.Build.Artifacts.Tasks
             public FileInfo DestFile { get; }
 
             public RobocopyMetadata Metadata { get; }
+
+            public FileInfo? ReplacementSourceFile { get; }
         }
     }
 }

--- a/src/Artifacts/Tasks/RobocopyMetadata.cs
+++ b/src/Artifacts/Tasks/RobocopyMetadata.cs
@@ -334,8 +334,8 @@ namespace Microsoft.Build.Artifacts.Tasks
                     else if (item.IndexOfAny(Wildcards) >= 0)
                     {
                         preRegex.Add(item);
-                        string regexString = item.Replace(@"\", @"\\").Replace(".", "[.]").Replace("?", ".").Replace("*", ".*");
-                        regularExpressions.Add(new Regex($"^{regexString}$", RegexOptions.IgnoreCase));
+                        string regexString = Robocopy.WildcardToRegexStr(item);
+                        regularExpressions.Add(new Regex($"^{regexString}$", FileSystem.PathRegexOptions));
                     }
                     else
                     {

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.targets
@@ -29,9 +29,9 @@
   <ItemGroup Condition="'$(EnableArtifacts)' != 'false' And '$(EnableDefaultArtifacts)' != 'false' And '$(ArtifactsPath)' != '' And '$(DefaultArtifactsSource)' != '' And '$(TargetFrameworks)' == ''">
     <!--
       By default copy the contents of $(DefaultArtifactsSource) (default is $(OutputPath)) to $(ArtifactsPath) unless:
-       * EnableDefaultArtifacts is 'false'
+       * $(EnableDefaultArtifacts) is 'false'
        * $(ArtifactsPath) is not specified
-       * $(TargetFramworks) is specified in which case the artifacts are copied in the outer build
+       * $(TargetFrameworks) is specified in which case the artifacts are copied in the outer build
     -->
     <Artifact Include="$(DefaultArtifactsSource)"
               DestinationFolder="$(ArtifactsPath)"

--- a/src/TestShared/MSBuildSdkTestBase.cs
+++ b/src/TestShared/MSBuildSdkTestBase.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Build.UnitTests.Common
             {
                 file.Directory?.Create();
 
-                File.WriteAllBytes(file.FullName, new byte[0]);
+                File.WriteAllText(file.FullName, file.FullName.Substring(directory.FullName.Length + 1));
             }
 
             return directory;


### PR DESCRIPTION
Previous logic did not understand chaining and sometimes would not copy some multi-hop files depending on parallel I/O ordering. Follow the chain back to the root and copy that forward to the destination in parallel.