### PR TITLE
Sync RunVSTestTask task params

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -21,6 +21,7 @@ trigger:
   paths:
     exclude:
     - '*.md'
+pr: none
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:

--- a/src/RunTests/RunVSTestTask.cs
+++ b/src/RunTests/RunVSTestTask.cs
@@ -18,11 +18,6 @@ namespace Microsoft.Build
         /// <summary>
         /// Gets or Sets Full path to the test file.
         /// </summary>
-        public string IsTestProject { get; set; }
-
-        /// <summary>
-        /// Gets or Sets Full path to the test file.
-        /// </summary>
         public string TestFileFullPath { get; set; }
 
         /// <summary>
@@ -64,19 +59,6 @@ namespace Microsoft.Build
         /// Gets or Sets Diagnostic data for VSTest.
         /// </summary>
         public string VSTestDiag { get; set; }
-
-        /// <summary>
-        /// Gets or Sets Command line options for VSTest.
-        /// </summary>
-        public string[] VSTestCLIRunSettings { get; set; }
-
-        // Initialized to empty string to allow declaring as non-nullable, the property is marked as
-        // required so we can ensure that the property is set to non-null before the task is executed.
-
-        /// <summary>
-        /// Gets or Sets Path to VSTest console executable.
-        /// </summary>
-        public string VSTestConsolePath { get; set; } = string.Empty;
 
         /// <summary>
         /// Gets or Sets Directory where VSTest results are saved.
@@ -147,12 +129,6 @@ namespace Microsoft.Build
         /// Gets or Sets Correlation Id of test session.
         /// </summary>
         public string VSTestSessionCorrelationId { get; set; }
-
-        /// <summary>
-        /// Gets or Sets Runner version of VSTest.
-        /// </summary>
-        [Required]
-        public string VSTestRunnerVersion { get; set; }
 
         protected override string ToolName => "vstest.console.exe";
 

--- a/src/RunTests/build/Microsoft.Build.RunVSTest.targets
+++ b/src/RunTests/build/Microsoft.Build.RunVSTest.targets
@@ -8,7 +8,6 @@
 	<UsingTask TaskName="Microsoft.Build.RunVSTestTask" AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.RunVSTest.dll"  Condition="'$(MSBuildRuntime)' != 'Core'"/>
 	<Target Name="RunVSTest" AfterTargets="Test" Condition="'$(MSBuildRuntime)' != 'Core'">
 		<RunVSTestTask
-				  VSTestRunnerVersion="$(VSTestRunnerVersion)"
 				  TestFileFullPath="$(TargetPath)"
 				  VSTestSetting="$(VSTestSetting)"
 				  VSTestTestAdapterPath="$(VSTestTestAdapterPath)"
@@ -16,6 +15,8 @@
 				  VSTestPlatform="$(VSTestPlatform)"
 				  VSTestTestCaseFilter="$(VSTestTestCaseFilter)"
 				  VSTestLogger="$(VSTestLogger)"
+				  VSTestListTests="$(VSTestListTests)"
+				  VSTestDiag="$(VSTestDiag)"
 				  VSTestResultsDirectory="$(VSTestResultsDirectory)"
 				  VSTestVerbosity="$(VSTestVerbosity)"
 				  VSTestCollect="$(VSTestCollect)"
@@ -25,6 +26,7 @@
 				  VSTestBlameCrashCollectAlways="$(VSTestBlameCrashCollectAlways)"
 				  VSTestBlameHang="$(VSTestBlameHang)"
 				  VSTestBlameHangDumpType="$(VSTestBlameHangDumpType)"
+				  VSTestBlameHangTimeout="$(VSTestBlameHangTimeout)"
 				  VSTestTraceDataCollectorDirectoryPath="$(VSTestTraceDataCollectorDirectoryPath)"
 				  VSTestNoLogo="$(VSTestNoLogo)"
 				  VSTestArtifactsProcessingMode="$(VSTestArtifactsProcessingMode)"


### PR DESCRIPTION
Sync RunVSTestTask task params

Seeing this when I simply PackageReference `Microsoft.Build.RunVSTest` and run `msbuild /t:Build;Test`:
```
D:\Code\.nuget\microsoft.build.runvstest\1.0.312-gef8f11a7a1\build\Microsoft.Build.RunVSTest.targets(10,3): error MSB4044: The "RunVSTestTask" task was not given a value for the required parameter "VSTestRunnerVersion".
```

`VSTestRunnerVersion` is a `Required` param but isn't used at all.

This change synchronizes the params in the task and in the targets file so they're aligned.