### PR TITLE
Avoid running tests against non-test projects

### DIFF
--- a/src/RunTests/build/Microsoft.Build.RunVSTest.targets
+++ b/src/RunTests/build/Microsoft.Build.RunVSTest.targets
@@ -5,8 +5,8 @@
   Licensed under the MIT license.
 -->
 <Project  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Microsoft.Build.RunVSTestTask" AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.RunVSTest.dll"  Condition="'$(MSBuildRuntime)' != 'Core'"/>
-	<Target Name="RunVSTest" AfterTargets="Test" Condition="'$(MSBuildRuntime)' != 'Core'">
+	<UsingTask TaskName="Microsoft.Build.RunVSTestTask" AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.RunVSTest.dll"  Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' != 'Core'"/>
+	<Target Name="RunVSTest" AfterTargets="Test" Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' != 'Core'">
 		<RunVSTestTask
 				  TestFileFullPath="$(TargetPath)"
 				  VSTestSetting="$(VSTestSetting)"
@@ -33,7 +33,7 @@
 				  VSTestSessionCorrelationId="$(VSTestSessionCorrelationId)"
 	/>
 	</Target>
-	<Target Name="ForceRunVSTest" AfterTargets="Test" Condition="'$(MSBuildRuntime)' == 'Core'" >
+	<Target Name="ForceRunVSTest" AfterTargets="Test" Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' == 'Core'" >
 		<CallTarget Targets="VSTest" />
 	</Target>
 </Project>


### PR DESCRIPTION
Without this, a global package reference both:
a) Attempts to run tests against dev projects, which can take ~500ms anecdotally, only to nop
b) Attempts to run tests against traversal projects, which don't actually produce an output, which hard fails when it can't find "dirs.dll"