### PR TITLE
RunVSTest: Allow overriding the ToolExe/ToolPath

### DIFF
--- a/src/RunTests/RunVSTestTask.cs
+++ b/src/RunTests/RunVSTestTask.cs
@@ -139,7 +139,15 @@ namespace Microsoft.Build
         /// <inheritdoc/>
         protected override string GenerateFullPathToTool()
         {
-            return $@"{Environment.GetEnvironmentVariable("VSINSTALLDIR")}\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe";
+            // Attempt to look in the VS installation dir
+            string vsInstallDir = Environment.GetEnvironmentVariable("VSINSTALLDIR");
+            if (!string.IsNullOrEmpty(vsInstallDir))
+            {
+                return $@"{vsInstallDir}\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe";
+            }
+
+            // Fallback to looking for the tool on the PATH
+            return ToolExe;
         }
 
         /// <inheritdoc/>

--- a/src/RunTests/build/Microsoft.Build.RunVSTest.props
+++ b/src/RunTests/build/Microsoft.Build.RunVSTest.props
@@ -4,8 +4,8 @@
   
   Licensed under the MIT license.
 -->
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project>
   <PropertyGroup>
-	<UseMSBuildTestInfrastructure Condition="$(UseMSBuildTestInfrastructure)==''">true</UseMSBuildTestInfrastructure>
+    <UseMSBuildTestInfrastructure Condition="'$(UseMSBuildTestInfrastructure)' == ''">true</UseMSBuildTestInfrastructure>
   </PropertyGroup>
 </Project>

--- a/src/RunTests/build/Microsoft.Build.RunVSTest.targets
+++ b/src/RunTests/build/Microsoft.Build.RunVSTest.targets
@@ -4,36 +4,36 @@
   
   Licensed under the MIT license.
 -->
-<Project  xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-	<UsingTask TaskName="Microsoft.Build.RunVSTestTask" AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.RunVSTest.dll"  Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' != 'Core'"/>
-	<Target Name="RunVSTest" AfterTargets="Test" Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' != 'Core'">
-		<RunVSTestTask
-				  TestFileFullPath="$(TargetPath)"
-				  VSTestSetting="$(VSTestSetting)"
-				  VSTestTestAdapterPath="$(VSTestTestAdapterPath)"
-				  VSTestFramework="$(VSTestFramework)"
-				  VSTestPlatform="$(VSTestPlatform)"
-				  VSTestTestCaseFilter="$(VSTestTestCaseFilter)"
-				  VSTestLogger="$(VSTestLogger)"
-				  VSTestListTests="$(VSTestListTests)"
-				  VSTestDiag="$(VSTestDiag)"
-				  VSTestResultsDirectory="$(VSTestResultsDirectory)"
-				  VSTestVerbosity="$(VSTestVerbosity)"
-				  VSTestCollect="$(VSTestCollect)"
-				  VSTestBlame="$(VSTestBlame)"
-				  VSTestBlameCrash="$(VSTestBlameCrash)"
-				  VSTestBlameCrashDumpType="$(VSTestBlameCrashDumpType)"
-				  VSTestBlameCrashCollectAlways="$(VSTestBlameCrashCollectAlways)"
-				  VSTestBlameHang="$(VSTestBlameHang)"
-				  VSTestBlameHangDumpType="$(VSTestBlameHangDumpType)"
-				  VSTestBlameHangTimeout="$(VSTestBlameHangTimeout)"
-				  VSTestTraceDataCollectorDirectoryPath="$(VSTestTraceDataCollectorDirectoryPath)"
-				  VSTestNoLogo="$(VSTestNoLogo)"
-				  VSTestArtifactsProcessingMode="$(VSTestArtifactsProcessingMode)"
-				  VSTestSessionCorrelationId="$(VSTestSessionCorrelationId)"
-	/>
-	</Target>
-	<Target Name="ForceRunVSTest" AfterTargets="Test" Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' == 'Core'" >
-		<CallTarget Targets="VSTest" />
-	</Target>
+<Project>
+  <UsingTask TaskName="Microsoft.Build.RunVSTestTask" AssemblyFile="$(MSBuildThisFileDirectory)netstandard2.0\Microsoft.Build.RunVSTest.dll" Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' != 'Core'"/>
+  <Target Name="RunVSTest" AfterTargets="Test" Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' != 'Core'">
+    <RunVSTestTask ToolExe="$(VSTestToolExe)"
+                   ToolPath="$(VSTestToolPath)"
+                   TestFileFullPath="$(TargetPath)"
+                   VSTestSetting="$(VSTestSetting)"
+                   VSTestTestAdapterPath="$(VSTestTestAdapterPath)"
+                   VSTestFramework="$(VSTestFramework)"
+                   VSTestPlatform="$(VSTestPlatform)"
+                   VSTestTestCaseFilter="$(VSTestTestCaseFilter)"
+                   VSTestLogger="$(VSTestLogger)"
+                   VSTestListTests="$(VSTestListTests)"
+                   VSTestDiag="$(VSTestDiag)"
+                   VSTestResultsDirectory="$(VSTestResultsDirectory)"
+                   VSTestVerbosity="$(VSTestVerbosity)"
+                   VSTestCollect="$(VSTestCollect)"
+                   VSTestBlame="$(VSTestBlame)"
+                   VSTestBlameCrash="$(VSTestBlameCrash)"
+                   VSTestBlameCrashDumpType="$(VSTestBlameCrashDumpType)"
+                   VSTestBlameCrashCollectAlways="$(VSTestBlameCrashCollectAlways)"
+                   VSTestBlameHang="$(VSTestBlameHang)"
+                   VSTestBlameHangDumpType="$(VSTestBlameHangDumpType)"
+                   VSTestBlameHangTimeout="$(VSTestBlameHangTimeout)"
+                   VSTestTraceDataCollectorDirectoryPath="$(VSTestTraceDataCollectorDirectoryPath)"
+                   VSTestNoLogo="$(VSTestNoLogo)"
+                   VSTestArtifactsProcessingMode="$(VSTestArtifactsProcessingMode)"
+                   VSTestSessionCorrelationId="$(VSTestSessionCorrelationId)" />
+  </Target>
+  <Target Name="ForceRunVSTest" AfterTargets="Test" Condition="'$(IsTestProject)' == 'true' and '$(MSBuildRuntime)' == 'Core'" >
+    <CallTarget Targets="VSTest" />
+  </Target>
 </Project>


### PR DESCRIPTION
The `ToolTask` has built-in parameters for `ToolExe`/`ToolPath` which allow callers to override the tool being called. This lights those up for the `RunVSTestTask`

There's also a minor change to avoid using an undefined `%VSINSTALLDIR%` and instead fallback to looking in the `PATH` (behavior when returning a filename from `GenerateFullPathToTool`).

Reference to relevant `ToolTask` logic: https://github.com/dotnet/msbuild/blob/7ca3c98fad986066bbf2802c863236b4a0f4e34a/src/Utilities/ToolTask.cs#L503-L566