### PR TITLE
Set default SlnGenProjectName for Traversal projects

### DIFF
--- a/src/Traversal.UnitTests/TraversalTests.cs
+++ b/src/Traversal.UnitTests/TraversalTests.cs
@@ -208,10 +208,12 @@ namespace Microsoft.Build.Traversal.UnitTests
         [InlineData("TraversalProjectNames", "custom.proj", "custom.proj")]
         [InlineData("TraversalProjectNames", null, "dirs.proj")]
         [InlineData("UsingMicrosoftTraversalSdk", null, "true")]
+        [InlineData("SlnGenProjectName", null, "ProjectA")]
+        [InlineData("SlnGenProjectName", "custom", "custom")]
         public void PropertiesHaveExpectedValues(string propertyName, string value, string expectedValue)
         {
             ProjectCreator.Templates.TraversalProject(
-                path: GetTempFile("dirs.proj"))
+                path: Path.Combine(TestRootPath, "ProjectA", "dirs.proj"))
                 .Property(propertyName, value)
                 .Save()
                 .TryGetPropertyValue(propertyName, out string actualValue);

--- a/src/Traversal/Sdk/Traversal.targets
+++ b/src/Traversal/Sdk/Traversal.targets
@@ -31,6 +31,17 @@
     <TargetFramework Condition="'$(TargetFramework)' == ''">net45</TargetFramework>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <!--
+      If the project hasn't customized its name, use the name of the parent folder. This avoids every IDE window being named "dirs".
+
+      We check the property twice to handle the unlikely situation where the project is at the root of a drive, and thus
+      the folder would otherwise be ''.
+    -->
+    <SlnGenProjectName Condition="'$(SlnGenProjectName)' == ''">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildProjectFullPath)))))</SlnGenProjectName>
+    <SlnGenProjectName Condition="'$(SlnGenProjectName)' == ''">$(MSBuildProjectName)</SlnGenProjectName>
+  </PropertyGroup>
+
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 
   <ItemGroup>


### PR DESCRIPTION
microsoft/slngen#557 added support for customizing the solution name using the MSBuild property `<SlnGenProjectName>`.

Today, if a user runs SlnGen with default properties, every VS window will unhelpfully be named "dirs". With this change, if a user hasn't set this property, this change sets it to the parent directory name, which is _usually_ more descriptive. In some cases that may result in equally unhelpful names like "src", but that's no worse than today.

This may be considered a breaking change for SlnGen users in some scenarios. Specifically, if they were running slngen with no parameters set and then assuming the resulting solution would be named `{dirs}.sln`. In many cases, anyone that's writing scripts with slngen is also setting `-o|--solutionfile`, so they wouldn't be impacted, but I'm sure _someone_ is relying on the name.