### PR TITLE
Update NoTargets sample version to avoid build warning

### DIFF
--- a/samples/NoTargets/SampleNoTargets/SampleNoTargets.csproj
+++ b/samples/NoTargets/SampleNoTargets/SampleNoTargets.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.0">
+﻿<Project Sdk="Microsoft.Build.NoTargets/3.7.56">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>


### PR DESCRIPTION
Update the NoTargets SDK version used by the NoTargets sample to avoid this warning during build:

```
MSBuildSdks\samples\NoTargets\SampleNoTargets\SampleNoTargets.csproj : warning MSB4240: Multiple versions of the same
SDK "Microsoft.Build.NoTargets" cannot be specified. The previously resolved SDK version "3.7.56" from location
"MSBuildSdks\src\NoTargets\Microsoft.Build.NoTargets.csproj" will be used and the version "3.7.0" will be ignored.
[MSBuildSdks\MSBuildSdks.sln]
```