### PR TITLE
Dont use IndexOf as that has Cuture issues

### DIFF
--- a/src/Traversal/Sdk/Traversal.props
+++ b/src/Traversal/Sdk/Traversal.props
@@ -13,7 +13,7 @@
     -->
     <TraversalProjectNames Condition=" '$(TraversalProjectNames)' == '' ">dirs.proj</TraversalProjectNames>
 
-    <IsTraversal Condition=" '$(IsTraversal)' == '' And $(TraversalProjectNames.IndexOf($(MSBuildProjectFile), System.StringComparison.OrdinalIgnoreCase)) >= 0 ">true</IsTraversal>
+    <IsTraversal Condition=" '$(IsTraversal)' == '' And '$(TraversalProjectNames.IndexOf($(MSBuildProjectFile), System.StringComparison.OrdinalIgnoreCase))' != '0' ">true</IsTraversal>
 
     <!--
       NuGet should always restore Traversal projects with "PackageReference" style restore.  Setting this property will cause the right thing to happen even if there aren't any PackageReference items in the project.


### PR DESCRIPTION
Theres currently some culture issues using IndexOf as mentioned in this issue https://github.com/dotnet/msbuild/issues/5502.
https://github.com/dotnet/msbuild/issues/5502 fixes it, but its only enabled in a late wave, that we are not depending on yet.
This PR uses contains instead, it seem that fixes the issue with Culture for now.