### PR TITLE
Update NoTargets Sdk.targets to fix typo

### DIFF
--- a/src/NoTargets/Sdk/Sdk.targets
+++ b/src/NoTargets/Sdk/Sdk.targets
@@ -101,6 +101,6 @@
   <Target Name="_GenerateCompileInputs" />
   <Target Name="_GenerateCompileDependencyCache" />
 
-  <!-- Disables the _CopyFilesMarkedCopyLocal target to not copy references when SkipCopyFilesMarkedCopyLocal is set to false. -->
+  <!-- Disables the _CopyFilesMarkedCopyLocal target to not copy references when SkipCopyFilesMarkedCopyLocal is set to true. -->
   <Import Project="DisableCopyFilesMarkedCopyLocal.targets" Condition="'$(SkipCopyFilesMarkedCopyLocal)' == 'true'" />
 </Project>


### PR DESCRIPTION
_CopyFilesMarkedCopyLocal target is disabled when SkipCopyFilesMarkedCopyLocal is set to **true**