### PR TITLE
Update to latest CopyOnWrite package

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,7 +8,7 @@
     <MicrosoftBuildMinimumPackageVersion>16.11.0</MicrosoftBuildMinimumPackageVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="CopyOnWrite" Version="0.4.2" Condition=" '$(TargetFramework)' != 'net46' " />
+    <PackageVersion Include="CopyOnWrite" Version="0.5.0" Condition=" '$(TargetFramework)' != 'net46' " />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
That removes EOL .NET 6 support and targets 8.0 instead (and netstandard2.0).