### PR TITLE
Ensure installation occurs exactly once, add msrustup file env var 

### DIFF
--- a/src/Cargo.UnitTests/CargoTest.cs
+++ b/src/Cargo.UnitTests/CargoTest.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Build.Cargo.UnitTests
                 .Save()
                 .TryGetPropertyValue(propertyName, out string actualValue);
 
-            actualValue.ShouldBe(expectedValue, StringComparer.OrdinalIgnoreCase, customMessage: $"Property {propertyName} should have a value of \"{expectedValue}\" but its value was \"{actualValue}\"");
+            actualValue.Trim().ShouldBe(expectedValue, StringComparer.OrdinalIgnoreCase, customMessage: $"Property {propertyName} should have a value of \"{expectedValue}\" but its value was \"{actualValue}\"");
         }
 
         [Theory]

--- a/src/Cargo.UnitTests/CargoTest.cs
+++ b/src/Cargo.UnitTests/CargoTest.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Build.Cargo.UnitTests
         {
             ProjectCreator cargoProject = ProjectCreator.Templates.CargoProject(
                     path: Path.Combine(TestRootPath, "Cargo", "rust.cargoproj"))
+                .Target("CargoInstall")
                 .Target("CargoFetch")
                 .Target("CargoBuild")
                 .Target(targetName)
@@ -60,6 +61,7 @@ namespace Microsoft.Build.Cargo.UnitTests
             ProjectCreator cargoProject = ProjectCreator.Templates.CargoProject(
                     path: Path.Combine(TestRootPath, "Cargo", "rust.cargoproj"))
                 .Property("CoreCompileDependsOn", "$(CoreCompileDependsOn);TestThatCoreCompileIsExtensible")
+                .Target("CargoInstall")
                 .Target("CargoFetch")
                 .Target("CargoBuild")
                 .Target("TestThatCoreCompileIsExtensible")
@@ -80,6 +82,7 @@ namespace Microsoft.Build.Cargo.UnitTests
                     path: Path.Combine(TestRootPath, "Cargo", "rust.cargoproj"))
                 .Property("TargetsTriggeredByCompilation", "TestThatCoreCompileIsExtensible")
                 .Property("TargetsTriggeredByCompilation", "TestThatCoreCompileIsExtensible")
+                .Target("CargoInstall")
                 .Target("CargoFetch")
                 .Target("CargoBuild")
                 .Target("TestThatCoreCompileIsExtensible")
@@ -107,7 +110,7 @@ namespace Microsoft.Build.Cargo.UnitTests
 
             ProjectCreator cargoProject = ProjectCreator.Templates.CargoProject(
                     path: Path.Combine(TestRootPath, "Cargo", "rust.cargoproj"))
-
+                .Target("CargoInstall")
                 .Target("CargoFetch")
                 .Target("CargoBuild")
                 .ItemProjectReference(projectA)
@@ -241,6 +244,7 @@ namespace Microsoft.Build.Cargo.UnitTests
                                 .TaskMessage("2EA26E6FC5C842B682AA26096A769E07", MessageImportance.High);
                     })
 
+                .Target("CargoInstall")
                 .Target("CargoFetch")
                 .Target("CargoBuild")
                 .Save()

--- a/src/Cargo.UnitTests/CargoTest.cs
+++ b/src/Cargo.UnitTests/CargoTest.cs
@@ -226,7 +226,7 @@ namespace Microsoft.Build.Cargo.UnitTests
                 .Save()
                 .TryGetPropertyValue(propertyName, out string actualValue);
 
-            actualValue.Trim().ShouldBe(expectedValue, StringComparer.OrdinalIgnoreCase, customMessage: $"Property {propertyName} should have a value of \"{expectedValue}\" but its value was \"{actualValue}\"");
+            actualValue.ShouldBe(expectedValue, StringComparer.OrdinalIgnoreCase, customMessage: $"Property {propertyName} should have a value of \"{expectedValue}\" but its value was \"{actualValue}\"");
         }
 
         [Theory]

--- a/src/Cargo/CargoTask.cs
+++ b/src/Cargo/CargoTask.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Build.Cargo
         private static readonly string _rustupHome = $"{_tempPath}\\rustuphome";
         private static readonly string _cargoHomeBin = $"{_tempPath}\\cargohome\\bin\\";
         private static readonly string _msRustupBinary = $"{_tempPath}\\cargohome\\bin\\msrustup.exe";
-        private static readonly Dictionary<string, string> _envVars = new() { { "CARGO_HOME", _cargoHome }, { "RUSTUP_HOME", _rustupHome } };
+        private static readonly Dictionary<string, string> _envVars = new () { { "CARGO_HOME", _cargoHome }, { "RUSTUP_HOME", _rustupHome } };
         private static readonly string _rustupDownloadLink = "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe";
         private static readonly string _checkSumVerifyUrl = "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe.sha256";
         private bool _shouldCleanRustPath;

--- a/src/Cargo/Microsoft.Build.Cargo.csproj
+++ b/src/Cargo/Microsoft.Build.Cargo.csproj
@@ -4,6 +4,7 @@
   <Nullable>enable</Nullable>
   <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
   <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+  <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>
   <PackageId>Microsoft.Build.Cargo</PackageId>
   <Description>Builds rust projects within msbuild using cargo.</Description>
   <NoDefaultExcludes>true</NoDefaultExcludes>

--- a/src/Cargo/Microsoft.Build.Cargo.csproj
+++ b/src/Cargo/Microsoft.Build.Cargo.csproj
@@ -22,19 +22,19 @@
     <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" VersionOverride="17.11.4" />
     <PackageReference Include="System.Net.Http" NoWarn="RT0003" />
   </ItemGroup>
-	<ItemGroup>
-		<None Include="dist\msrustup.ps1">
-			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-			<Pack>true</Pack>
+  <ItemGroup>
+    <None Include="dist\msrustup.ps1">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Pack>true</Pack>
 		</None>
-		<None Include="README.md" />
+    <None Include="README.md" />
     <None Include="sdk\Sdk.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="sdk\Sdk.targets">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Include="sdk\cargoinstall.proj">
+    <None Include="sdk\CargoInstall.proj">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="sdk\DisableCopyFilesMarkedCopyLocal.targets">

--- a/src/Cargo/Microsoft.Build.Cargo.csproj
+++ b/src/Cargo/Microsoft.Build.Cargo.csproj
@@ -19,14 +19,15 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="17.11.4" />
     <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" VersionOverride="17.11.4" />
-    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" VersionOverride="17.11.4" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime"
+      VersionOverride="17.11.4" />
     <PackageReference Include="System.Net.Http" NoWarn="RT0003" />
   </ItemGroup>
   <ItemGroup>
     <None Include="dist\msrustup.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <Pack>true</Pack>
-		</None>
+    </None>
     <None Include="README.md" />
     <None Include="sdk\Sdk.props">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/Cargo/Microsoft.Build.Cargo.csproj
+++ b/src/Cargo/Microsoft.Build.Cargo.csproj
@@ -1,50 +1,44 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  <ImplicitUsings>enable</ImplicitUsings>
-  <Nullable>enable</Nullable>
-  <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
-  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-  <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>
-  <PackageId>Microsoft.Build.Cargo</PackageId>
-  <Description>Builds rust projects within msbuild using cargo.</Description>
-  <NoDefaultExcludes>true</NoDefaultExcludes>
-  <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
-  <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
-  <DevelopmentDependency>true</DevelopmentDependency>
-  <!-- This package contains MSBuild tasks only, so avoid dependencies. -->
-  <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
-  <OutputFileNamesWithoutVersion>false</OutputFileNamesWithoutVersion>
-  <NoWarn>$(NoWarn);NU1504;NU5100;NU5110;NU5111</NoWarn>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>
+    <PackageId>Microsoft.Build.Cargo</PackageId>
+    <Description>Builds rust projects within msbuild using cargo.</Description>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <BuildOutputTargetFolder>build\</BuildOutputTargetFolder>
+    <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <!-- This package contains MSBuild tasks only, so avoid dependencies. -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <OutputFileNamesWithoutVersion>false</OutputFileNamesWithoutVersion>
+    <NoWarn>$(NoWarn);NU1504;NU5100;NU5110;NU5111</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="dist\msrustup.ps1">
-  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    <Pack>true</Pack>
-      </None>
-      <None Include="README.md" />
-    </ItemGroup>
- <ItemGroup>
-   <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="17.11.4" />
-   <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" VersionOverride="17.11.4" />
-   <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" VersionOverride="17.11.4" />
-   <PackageReference Include="System.Net.Http" NoWarn="RT0003" />
- </ItemGroup>
- <ItemGroup>
-   <None Include="sdk\Sdk.props">
-     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-   </None>
- </ItemGroup>
- <ItemGroup>
-   <None Include="sdk\Sdk.targets">
-     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-   </None>
-	 <None Include="sdk\cargoinstall.proj">
-		 <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	 </None>
- </ItemGroup>
- <ItemGroup>
-   <None Include="sdk\DisableCopyFilesMarkedCopyLocal.targets">
-     <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-   </None>
- </ItemGroup>
+    <PackageReference Include="Microsoft.Build.Utilities.Core" VersionOverride="17.11.4" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" VersionOverride="17.11.4" />
+    <PackageReference Include="Microsoft.Build.Framework" ExcludeAssets="runtime" VersionOverride="17.11.4" />
+    <PackageReference Include="System.Net.Http" NoWarn="RT0003" />
+  </ItemGroup>
+	<ItemGroup>
+		<None Include="dist\msrustup.ps1">
+			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+			<Pack>true</Pack>
+		</None>
+		<None Include="README.md" />
+    <None Include="sdk\Sdk.props">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="sdk\Sdk.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="sdk\cargoinstall.proj">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="sdk\DisableCopyFilesMarkedCopyLocal.targets">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/src/Cargo/Microsoft.Build.Cargo.csproj
+++ b/src/Cargo/Microsoft.Build.Cargo.csproj
@@ -38,6 +38,9 @@
    <None Include="sdk\Sdk.targets">
      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
    </None>
+	 <None Include="sdk\cargoinstall.proj">
+		 <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	 </None>
  </ItemGroup>
  <ItemGroup>
    <None Include="sdk\DisableCopyFilesMarkedCopyLocal.targets">

--- a/src/Cargo/dist/msrustup.ps1
+++ b/src/Cargo/dist/msrustup.ps1
@@ -51,12 +51,20 @@ $feed = if (Test-Path env:MSRUSTUP_FEED_URL) {
 # Get authentication token
 $token = if (Test-Path env:MSRUSTUP_ACCESS_TOKEN) {
     "Bearer $env:MSRUSTUP_ACCESS_TOKEN"
+
 } elseif (Test-Path env:MSRUSTUP_PAT) {
     "Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$($env:MSRUSTUP_PAT)")))"
-} elseif ((Get-Command "azureauth" -ErrorAction SilentlyContinue) -ne $null) {
+} elseif (Test-Path env:MSRUSTUP_FILE) {
+    $location = $env:MSRUSTUP_FILE
+    if (Test-Path $location) {
+        $contents = Get-Content $location -Raw
+    }
+    "Basic $([System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":$($contents)")))"
+}
+elseif ((Get-Command "azureauth" -ErrorAction SilentlyContinue) -ne $null) {
     azureauth ado token --output headervalue
 } else {
-    Write-Error "MSRUSTUP_ACCESS_TOKEN or MSRUSTUP_PAT must be set or azureauth must be present."
+    Write-Error "MSRUSTUP_ACCESS_TOKEN, MSRUSTUP_FILE or MSRUSTUP_PAT must be set or azureauth must be present."
     exit 1
 }
 

--- a/src/Cargo/sdk/CargoInstall.proj
+++ b/src/Cargo/sdk/CargoInstall.proj
@@ -1,13 +1,8 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)sdk.props" />
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
-    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll"
-    Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
-    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll"
-    Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
+  <Import Project="$(MSBuildThisFileDirectory)Sdk.props"/>
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
   <Target Name="CargoInstall">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(MSBuildStartupDirectory)" Command="install"
-      UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(MSBuildStartupDirectory)" Command="install" UseMsRustUp="$(UseMsRustUp)"/>
   </Target>
 </Project>

--- a/src/Cargo/sdk/CargoInstall.proj
+++ b/src/Cargo/sdk/CargoInstall.proj
@@ -1,8 +1,13 @@
 <Project>
-  <Import Project="$(MSBuildThisFileDirectory)sdk.props"/>
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
+  <Import Project="$(MSBuildThisFileDirectory)sdk.props" />
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
+    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll"
+    Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
+    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll"
+    Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
   <Target Name="CargoInstall">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(MSBuildStartupDirectory)" Command="install" UseMsRustUp="$(UseMsRustUp)"/>
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(MSBuildStartupDirectory)" Command="install"
+      UseMsRustUp="$(UseMsRustUp)" />
   </Target>
 </Project>

--- a/src/Cargo/sdk/CargoInstall.proj
+++ b/src/Cargo/sdk/CargoInstall.proj
@@ -1,0 +1,8 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)sdk.props"/>
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
+  <Target Name="CargoInstall">
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(MSBuildStartupDirectory)" Command="install" UseMsRustUp="$(UseMsRustUp)"/>
+  </Target>
+</Project>

--- a/src/Cargo/sdk/Sdk.props
+++ b/src/Cargo/sdk/Sdk.props
@@ -6,8 +6,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <UsingMicrosoftCargoSdk>true</UsingMicrosoftCargoSdk>
-    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">
-      $(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -16,30 +14,24 @@
     <ManagedLanguageTargetsGotImported Condition="'$(MSBuildProjectExtension)' == '.fsproj'">true</ManagedLanguageTargetsGotImported>
   </PropertyGroup>
 
-  <Import Project="$(CustomBeforeCargoProps)"
-    Condition=" '$(CustomBeforeCargoProps)' != '' And Exists('$(CustomBeforeCargoProps)') " />
+  <Import Project="$(CustomBeforeCargoProps)" Condition=" '$(CustomBeforeCargoProps)' != '' And Exists('$(CustomBeforeCargoProps)') " />
 
   <PropertyGroup>
     <!-- Disable default Compile and EmbeddedResource items for Cargo projects -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-
+    
     <!--
-      NuGet should always restore Cargo projects with "PackageReference" style restore.  Setting this
-    property will cause the right thing to happen even if there aren't any PackageReference items in
-    the project.
+      NuGet should always restore Cargo projects with "PackageReference" style restore.  Setting this property will cause the right thing to happen even if there aren't any PackageReference items in the project.
     -->
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
     <!-- Targeting packs shouldn't be referenced as Cargo projects don't compile .net code. -->
-    <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">
-      true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">true</DisableImplicitFrameworkReferences>
 
     <!-- Disable publish actions -->
-    <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)' == ''">
-      false</CopyBuildOutputToPublishDirectory>
-    <CopyOutputSymbolsToPublishDirectory Condition="'$(CopyOutputSymbolsToPublishDirectory)' == ''">
-      false</CopyOutputSymbolsToPublishDirectory>
+    <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)' == ''">false</CopyBuildOutputToPublishDirectory>
+    <CopyOutputSymbolsToPublishDirectory Condition="'$(CopyOutputSymbolsToPublishDirectory)' == ''">false</CopyOutputSymbolsToPublishDirectory>
 
     <!-- Don't generate a deps file -->
     <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">false</GenerateDependencyFile>
@@ -50,13 +42,11 @@
     <!-- Don't generate editor config file -->
     <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">false</GenerateMSBuildEditorConfigFile>
 
-    <!-- Don't log the high priority message mentioning this project's name (or copy the product we
-    didn't build). -->
+    <!-- Don't log the high priority message mentioning this project's name (or copy the product we didn't build). -->
     <SkipCopyBuildProduct Condition="'$(SkipCopyBuildProduct)' == ''">true</SkipCopyBuildProduct>
 
     <!-- Don't automatically reference assembly packages since Cargo don't need reference assemblies -->
-    <AutomaticallyUseReferenceAssemblyPackages
-      Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
+    <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
     <NoCompilerStandardLib Condition="'$(NoCompilerStandardLib)' == ''">false</NoCompilerStandardLib>
     <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
 
@@ -67,10 +57,8 @@
   <ItemDefinitionGroup>
     <ProjectReference>
       <!--
-        Setting ReferenceOutputAssembly skips target framework cross-project validation in NuGet.  Since
-      Cargo projects don't define runtime
-        constraints like a target framework, there's no point in checking the compatibilty of project
-      references.
+        Setting ReferenceOutputAssembly skips target framework cross-project validation in NuGet.  Since Cargo projects don't define runtime
+        constraints like a target framework, there's no point in checking the compatibilty of project references.
       -->
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
@@ -79,14 +67,11 @@
 
   <Target Name="CreateManifestResourceNames" />
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk"
-    Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' " />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>
 
-  <Import Project="$(CustomAfterCargoProps)"
-    Condition=" '$(CustomAfterCargoProps)' != '' And Exists('$(CustomAfterCargoProps)') " />
+  <Import Project="$(CustomAfterCargoProps)" Condition=" '$(CustomAfterCargoProps)' != '' And Exists('$(CustomAfterCargoProps)') " />
 
-  <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if
-  needed -->
+  <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if needed -->
   <Target Name="CompileDesignTime" />
 
   <!-- Rust specific props -->
@@ -97,8 +82,7 @@
     <CleanCommandArgs Condition="'$(CleanCommandArgs)' == ''"></CleanCommandArgs>
     <RunCommandArgs Condition="'$(RunCommandArgs)' == ''"></RunCommandArgs>
     <DocCommandArgs Condition="'$(DocCommandArgs)' == ''"></DocCommandArgs>
-    <!--For
-    internal Microsoft use only.-->
+    <!--For internal Microsoft use only.-->
     <UseMsRustup Condition="'$(UseMsRustup)' == ''">false</UseMsRustup>
     <StartupProj Condition="'$(StartupProj)' == ''">$(MSBuildProjectFullPath)</StartupProj>
   </PropertyGroup>

--- a/src/Cargo/sdk/Sdk.props
+++ b/src/Cargo/sdk/Sdk.props
@@ -6,7 +6,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <UsingMicrosoftCargoSdk>true</UsingMicrosoftCargoSdk>
-    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">
+      $(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -15,24 +16,30 @@
     <ManagedLanguageTargetsGotImported Condition="'$(MSBuildProjectExtension)' == '.fsproj'">true</ManagedLanguageTargetsGotImported>
   </PropertyGroup>
 
-  <Import Project="$(CustomBeforeCargoProps)" Condition=" '$(CustomBeforeCargoProps)' != '' And Exists('$(CustomBeforeCargoProps)') " />
+  <Import Project="$(CustomBeforeCargoProps)"
+    Condition=" '$(CustomBeforeCargoProps)' != '' And Exists('$(CustomBeforeCargoProps)') " />
 
   <PropertyGroup>
     <!-- Disable default Compile and EmbeddedResource items for Cargo projects -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
-    
+
     <!--
-      NuGet should always restore Cargo projects with "PackageReference" style restore.  Setting this property will cause the right thing to happen even if there aren't any PackageReference items in the project.
+      NuGet should always restore Cargo projects with "PackageReference" style restore.  Setting this
+    property will cause the right thing to happen even if there aren't any PackageReference items in
+    the project.
     -->
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
 
     <!-- Targeting packs shouldn't be referenced as Cargo projects don't compile .net code. -->
-    <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">true</DisableImplicitFrameworkReferences>
+    <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">
+      true</DisableImplicitFrameworkReferences>
 
     <!-- Disable publish actions -->
-    <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)' == ''">false</CopyBuildOutputToPublishDirectory>
-    <CopyOutputSymbolsToPublishDirectory Condition="'$(CopyOutputSymbolsToPublishDirectory)' == ''">false</CopyOutputSymbolsToPublishDirectory>
+    <CopyBuildOutputToPublishDirectory Condition="'$(CopyBuildOutputToPublishDirectory)' == ''">
+      false</CopyBuildOutputToPublishDirectory>
+    <CopyOutputSymbolsToPublishDirectory Condition="'$(CopyOutputSymbolsToPublishDirectory)' == ''">
+      false</CopyOutputSymbolsToPublishDirectory>
 
     <!-- Don't generate a deps file -->
     <GenerateDependencyFile Condition="'$(GenerateDependencyFile)' == ''">false</GenerateDependencyFile>
@@ -43,11 +50,13 @@
     <!-- Don't generate editor config file -->
     <GenerateMSBuildEditorConfigFile Condition="'$(GenerateMSBuildEditorConfigFile)' == ''">false</GenerateMSBuildEditorConfigFile>
 
-    <!-- Don't log the high priority message mentioning this project's name (or copy the product we didn't build). -->
+    <!-- Don't log the high priority message mentioning this project's name (or copy the product we
+    didn't build). -->
     <SkipCopyBuildProduct Condition="'$(SkipCopyBuildProduct)' == ''">true</SkipCopyBuildProduct>
 
     <!-- Don't automatically reference assembly packages since Cargo don't need reference assemblies -->
-    <AutomaticallyUseReferenceAssemblyPackages Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
+    <AutomaticallyUseReferenceAssemblyPackages
+      Condition="'$(AutomaticallyUseReferenceAssemblyPackages)' == ''">false</AutomaticallyUseReferenceAssemblyPackages>
     <NoCompilerStandardLib Condition="'$(NoCompilerStandardLib)' == ''">false</NoCompilerStandardLib>
     <NoStdLib Condition="'$(NoStdLib)' == ''">true</NoStdLib>
 
@@ -58,8 +67,10 @@
   <ItemDefinitionGroup>
     <ProjectReference>
       <!--
-        Setting ReferenceOutputAssembly skips target framework cross-project validation in NuGet.  Since Cargo projects don't define runtime
-        constraints like a target framework, there's no point in checking the compatibilty of project references.
+        Setting ReferenceOutputAssembly skips target framework cross-project validation in NuGet.  Since
+      Cargo projects don't define runtime
+        constraints like a target framework, there's no point in checking the compatibilty of project
+      references.
       -->
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
       <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
@@ -68,11 +79,14 @@
 
   <Target Name="CreateManifestResourceNames" />
 
-  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' "/>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk"
+    Condition=" '$(MicrosoftCommonPropsHasBeenImported)' != 'true' " />
 
-  <Import Project="$(CustomAfterCargoProps)" Condition=" '$(CustomAfterCargoProps)' != '' And Exists('$(CustomAfterCargoProps)') " />
+  <Import Project="$(CustomAfterCargoProps)"
+    Condition=" '$(CustomAfterCargoProps)' != '' And Exists('$(CustomAfterCargoProps)') " />
 
-  <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if needed -->
+  <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if
+  needed -->
   <Target Name="CompileDesignTime" />
 
   <!-- Rust specific props -->
@@ -83,7 +97,8 @@
     <CleanCommandArgs Condition="'$(CleanCommandArgs)' == ''"></CleanCommandArgs>
     <RunCommandArgs Condition="'$(RunCommandArgs)' == ''"></RunCommandArgs>
     <DocCommandArgs Condition="'$(DocCommandArgs)' == ''"></DocCommandArgs>
-    <!--For internal Microsoft use only.-->
+    <!--For
+    internal Microsoft use only.-->
     <UseMsRustup Condition="'$(UseMsRustup)' == ''">false</UseMsRustup>
     <StartupProj Condition="'$(StartupProj)' == ''">$(MSBuildProjectFullPath)</StartupProj>
   </PropertyGroup>

--- a/src/Cargo/sdk/Sdk.props
+++ b/src/Cargo/sdk/Sdk.props
@@ -85,6 +85,7 @@
     <DocCommandArgs Condition="'$(DocCommandArgs)' == ''"></DocCommandArgs>
     <!--For internal Microsoft use only.-->
     <UseMsRustup Condition="'$(UseMsRustup)' == ''">false</UseMsRustup>
+    <StartupProj Condition="'$(StartupProj)' == ''">$(MSBuildProjectFullPath)</StartupProj>
   </PropertyGroup>
   <ItemGroup>
     <None Include="**\*.rs" />

--- a/src/Cargo/sdk/Sdk.targets
+++ b/src/Cargo/sdk/Sdk.targets
@@ -9,26 +9,35 @@
     <TargetFramework Condition="'$(TargetFramework)' == ''">netstandard2.0</TargetFramework>
   </PropertyGroup>
   <!--
-    Set LanguageTargets to Microsoft.Common.targets for any project that the SDK won't (.proj, .noproj, etc)
-    https://github.com/dotnet/sdk/blob/50ddfbb91be94d068514e8f4b0ce1052156364a0/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28
+    Set LanguageTargets to Microsoft.Common.targets for any project that the SDK won't (.proj, .noproj,
+  etc)
+  https://github.com/dotnet/sdk/blob/50ddfbb91be94d068514e8f4b0ce1052156364a0/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28
     
-    We can't default LanguageTargets it is set in the SDK and immediately imported.  So we can only default
+    We can't default LanguageTargets it is set in the SDK and immediately imported.  So we can only
+  default
     it if we know the SDK won't.  Projects probably won't load in Visual Studio but will build from the
     command-line just fine.
   -->
   <PropertyGroup>
-    <LanguageTargets Condition=" '$(LanguageTargets)' == '' And '$(MSBuildProjectExtension)' != '.csproj' And '$(MSBuildProjectExtension)' != '.vbproj' And '$(MSBuildProjectExtension)' != '.fsproj' ">$(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
-    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+    <LanguageTargets
+      Condition=" '$(LanguageTargets)' == '' And '$(MSBuildProjectExtension)' != '.csproj' And '$(MSBuildProjectExtension)' != '.vbproj' And '$(MSBuildProjectExtension)' != '.fsproj' ">
+      $(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">
+      $(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Import Project="$(CustomBeforeCargo)" Condition="'$(CustomBeforeCargo)' != '' and Exists('$(CustomBeforeCargo)')" />
+  <Import Project="$(CustomBeforeCargo)"
+    Condition="'$(CustomBeforeCargo)' != '' and Exists('$(CustomBeforeCargo)')" />
 
   <PropertyGroup>
     <!-- Don't include build output in a package since CargoProj projects don't emit an assembly. -->
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)' == ''">false</IncludeBuildOutput>
 
-    <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
-    <CustomBeforeMicrosoftCommonTargets Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">$(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
+    <!-- For CPS/VS support. See
+    https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
+    <CustomBeforeMicrosoftCommonTargets
+      Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">
+      $(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
@@ -65,18 +74,21 @@
   </ItemGroup>
 
   <!--
-    The CopyFilesToOutputDirectory target is hard coded to depend on ComputeIntermediateSatelliteAssemblies.  Cargo projects do no generate resource assemblies
+    The CopyFilesToOutputDirectory target is hard coded to depend on
+  ComputeIntermediateSatelliteAssemblies.  Cargo projects do no generate resource assemblies
     so the target is replaced with a no-op
   -->
   <Target Name="ComputeIntermediateSatelliteAssemblies" />
 
   <!--
-    Cargo projects do not build an assembly so dependent projects shouldn't get a path to the target.  Override the GetTargetPath to do nothing.
+    Cargo projects do not build an assembly so dependent projects shouldn't get a path to the target.
+  Override the GetTargetPath to do nothing.
   -->
   <Target Name="GetTargetPath" />
 
   <!--
-    The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
+    The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable
+  it is to override it with an empty target.
   -->
   <Target Name="GetTargetPathWithTargetPlatformMoniker" />
 
@@ -86,54 +98,71 @@
   <Target Name="GetFrameworkPaths" DependsOnTargets="$(GetFrameworkPathsDependsOn)" />
   <Target Name="GetReferenceAssemblyPaths" DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)" />
 
-  <Import Project="$(CustomAfterCargo)" Condition="'$(CustomAfterCargo)' != '' and Exists('$(CustomAfterCargo)')" />
+  <Import Project="$(CustomAfterCargo)"
+    Condition="'$(CustomAfterCargo)' != '' and Exists('$(CustomAfterCargo)')" />
 
   <!-- 
-    Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
+    Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and
+  above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
     So import it when the managed targets do not get imported.
   -->
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets" Condition="'$(MSBuildAssemblyVersion)' >= '16.0' And '$(ManagedLanguageTargetsGotImported)' != 'true'" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets"
+    Condition="'$(MSBuildAssemblyVersion)' >= '16.0' And '$(ManagedLanguageTargetsGotImported)' != 'true'" />
 
   <!-- Override stock CoreCompile target to do nothing but keep extensibility points -->
   <Target Name="CoreCompile"
-      DependsOnTargets="$(CoreCompileDependsOn)">
-    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
+    DependsOnTargets="$(CoreCompileDependsOn)">
+    <CallTarget Targets="$(TargetsTriggeredByCompilation)"
+      Condition="'$(TargetsTriggeredByCompilation)' != ''" />
   </Target>
 
   <Target Name="_GenerateCompileInputs" />
   <Target Name="_GenerateCompileDependencyCache" />
 
-  <!-- Disables the _CopyFilesMarkedCopyLocal target to not copy references when SkipCopyFilesMarkedCopyLocal is set to true. -->
-  <Import Project="DisableCopyFilesMarkedCopyLocal.targets" Condition="'$(SkipCopyFilesMarkedCopyLocal)' == 'true'" />
+  <!-- Disables the _CopyFilesMarkedCopyLocal target to not copy references when
+  SkipCopyFilesMarkedCopyLocal is set to true. -->
+  <Import Project="DisableCopyFilesMarkedCopyLocal.targets"
+    Condition="'$(SkipCopyFilesMarkedCopyLocal)' == 'true'" />
   <!-- Rust specific targets -->
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
+    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll"
+    Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
+    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll"
+    Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
   <Target Name="CargoInstall" AfterTargets="_CollectRestoreInputs">
     <MSBuild
-       Projects="$(MSBuildThisFileDirectory)CargoInstall.proj"
-       Targets="CargoInstall"
-       Properties="EnableTelemetryLoggerCopy=$(EnableTelemetryLoggerCopy);TelemetryLoggerLocation=$(TelemetryLoggerLocation);TelemetryLoggerSourcePath=$(TelemetryLoggerSourcePath);TelemetryLoggerInstallId=$(TelemetryLoggerInstallId)"
-       RemoveProperties="NuGetInteractive;MSBuildRestoreSessionId;TargetFramework;RuntimeIdentifier" />
+      Projects="$(MSBuildThisFileDirectory)CargoInstall.proj"
+      Targets="CargoInstall"
+      Properties="EnableTelemetryLoggerCopy=$(EnableTelemetryLoggerCopy);TelemetryLoggerLocation=$(TelemetryLoggerLocation);TelemetryLoggerSourcePath=$(TelemetryLoggerSourcePath);TelemetryLoggerInstallId=$(TelemetryLoggerInstallId)"
+      RemoveProperties="NuGetInteractive;MSBuildRestoreSessionId;TargetFramework;RuntimeIdentifier" />
   </Target>
-	<Target Name="CargoFetch" AfterTargets="CargoInstall">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="fetch" UseMsRustUp="$(UseMsRustUp)" />
+  <Target Name="CargoFetch" AfterTargets="CargoInstall">
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="fetch"
+      UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="CargoBuild" AfterTargets="CoreCompile" DependsOnTargets="CargoFetch">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build" CommandArgs="$(BuildCommandArgs)" UseMsRustUp="$(UseMsRustUp)"  />
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build"
+      CommandArgs="$(BuildCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Test" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(TestCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(TestCommandArgs)"
+      UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Clean">
-    <CargoTask StartupProj="$(StartupProj)" Command="clean" CommandArgs="$(CleanCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="clean" CommandArgs="$(CleanCommandArgs)"
+      UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Run" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(StartupProj)" Command="run" CommandArgs="$(RunCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="run" CommandArgs="$(RunCommandArgs)"
+      UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Doc" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(StartupProj)" Command="doc" CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="doc" CommandArgs="$(DocCommandArgs)"
+      UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="ClearCargoCache">
-    <CargoTask StartupProj="$(StartupProj)" Command="clearcargocache" CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="clearcargocache"
+      CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
 </Project>

--- a/src/Cargo/sdk/Sdk.targets
+++ b/src/Cargo/sdk/Sdk.targets
@@ -108,25 +108,32 @@
   <!-- Rust specific targets -->
   <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
   <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'"/>
-  <Target Name="CargoFetch" AfterTargets="Restore">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(MSBuildProjectFullPath)" Command="fetch" />
+  <Target Name="CargoInstall" AfterTargets="_CollectRestoreInputs">
+    <MSBuild
+       Projects="$(MSBuildThisFileDirectory)CargoInstall.proj"
+       Targets="CargoInstall"
+       Properties="EnableTelemetryLoggerCopy=$(EnableTelemetryLoggerCopy);TelemetryLoggerLocation=$(TelemetryLoggerLocation);TelemetryLoggerSourcePath=$(TelemetryLoggerSourcePath);TelemetryLoggerInstallId=$(TelemetryLoggerInstallId)"
+       RemoveProperties="NuGetInteractive;MSBuildRestoreSessionId;TargetFramework;RuntimeIdentifier" />
+  </Target>
+	<Target Name="CargoFetch" AfterTargets="CargoInstall">
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="fetch" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="CargoBuild" AfterTargets="CoreCompile" DependsOnTargets="CargoFetch">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(MSBuildProjectFullPath)" Command="build" CommandArgs="$(BuildCommandArgs)" />
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build" CommandArgs="$(BuildCommandArgs)" UseMsRustUp="$(UseMsRustUp)"  />
   </Target>
   <Target Name="Test" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(MSBuildProjectFullPath)" Command="test" CommandArgs="$(TestCommandArgs)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(TestCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Clean">
-    <CargoTask StartupProj="$(MSBuildProjectFullPath)" Command="clean" CommandArgs="$(CleanCommandArgs)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="clean" CommandArgs="$(CleanCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Run" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(MSBuildProjectFullPath)" Command="run" CommandArgs="$(RunCommandArgs)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="run" CommandArgs="$(RunCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Doc" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(MSBuildProjectFullPath)" Command="doc" CommandArgs="$(DocCommandArgs)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="doc" CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="ClearCargoCache">
-    <CargoTask StartupProj="$(MSBuildProjectFullPath)" Command="clearcargocache" CommandArgs="$(DocCommandArgs)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="clearcargocache" CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
 </Project>

--- a/src/Cargo/sdk/Sdk.targets
+++ b/src/Cargo/sdk/Sdk.targets
@@ -9,35 +9,26 @@
     <TargetFramework Condition="'$(TargetFramework)' == ''">netstandard2.0</TargetFramework>
   </PropertyGroup>
   <!--
-    Set LanguageTargets to Microsoft.Common.targets for any project that the SDK won't (.proj, .noproj,
-  etc)
-  https://github.com/dotnet/sdk/blob/50ddfbb91be94d068514e8f4b0ce1052156364a0/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28
+    Set LanguageTargets to Microsoft.Common.targets for any project that the SDK won't (.proj, .noproj, etc)
+    https://github.com/dotnet/sdk/blob/50ddfbb91be94d068514e8f4b0ce1052156364a0/src/Tasks/Microsoft.NET.Build.Tasks/sdk/Sdk.targets#L28
     
-    We can't default LanguageTargets it is set in the SDK and immediately imported.  So we can only
-  default
+    We can't default LanguageTargets it is set in the SDK and immediately imported.  So we can only default
     it if we know the SDK won't.  Projects probably won't load in Visual Studio but will build from the
     command-line just fine.
   -->
   <PropertyGroup>
-    <LanguageTargets
-      Condition=" '$(LanguageTargets)' == '' And '$(MSBuildProjectExtension)' != '.csproj' And '$(MSBuildProjectExtension)' != '.vbproj' And '$(MSBuildProjectExtension)' != '.fsproj' ">
-      $(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
-    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">
-      $(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+    <LanguageTargets Condition=" '$(LanguageTargets)' == '' And '$(MSBuildProjectExtension)' != '.csproj' And '$(MSBuildProjectExtension)' != '.vbproj' And '$(MSBuildProjectExtension)' != '.fsproj' ">$(MSBuildToolsPath)\Microsoft.Common.targets</LanguageTargets>
+    <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
   </PropertyGroup>
 
-  <Import Project="$(CustomBeforeCargo)"
-    Condition="'$(CustomBeforeCargo)' != '' and Exists('$(CustomBeforeCargo)')" />
+  <Import Project="$(CustomBeforeCargo)" Condition="'$(CustomBeforeCargo)' != '' and Exists('$(CustomBeforeCargo)')" />
 
   <PropertyGroup>
     <!-- Don't include build output in a package since CargoProj projects don't emit an assembly. -->
     <IncludeBuildOutput Condition="'$(IncludeBuildOutput)' == ''">false</IncludeBuildOutput>
 
-    <!-- For CPS/VS support. See
-    https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
-    <CustomBeforeMicrosoftCommonTargets
-      Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">
-      $(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
+    <!-- For CPS/VS support. See https://github.com/dotnet/project-system/blob/master/src/Microsoft.VisualStudio.ProjectSystem.Managed/ProjectSystem/DesignTimeTargets/Microsoft.Managed.DesignTime.targets#L60 -->
+    <CustomBeforeMicrosoftCommonTargets Condition="'$(ManagedLanguageTargetsGotImported)' == '' And Exists('$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets')">$(CustomBeforeMicrosoftCommonTargets);$(MSBuildExtensionsPath)\Microsoft\VisualStudio\Managed\Microsoft.Managed.DesignTime.targets</CustomBeforeMicrosoftCommonTargets>
   </PropertyGroup>
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" Condition=" '$(CommonTargetsPath)' == '' " />
@@ -74,21 +65,18 @@
   </ItemGroup>
 
   <!--
-    The CopyFilesToOutputDirectory target is hard coded to depend on
-  ComputeIntermediateSatelliteAssemblies.  Cargo projects do no generate resource assemblies
+    The CopyFilesToOutputDirectory target is hard coded to depend on ComputeIntermediateSatelliteAssemblies.  Cargo projects do no generate resource assemblies
     so the target is replaced with a no-op
   -->
   <Target Name="ComputeIntermediateSatelliteAssemblies" />
 
   <!--
-    Cargo projects do not build an assembly so dependent projects shouldn't get a path to the target.
-  Override the GetTargetPath to do nothing.
+    Cargo projects do not build an assembly so dependent projects shouldn't get a path to the target.  Override the GetTargetPath to do nothing.
   -->
   <Target Name="GetTargetPath" />
 
   <!--
-    The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable
-  it is to override it with an empty target.
+    The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
   -->
   <Target Name="GetTargetPathWithTargetPlatformMoniker" />
 
@@ -98,71 +86,54 @@
   <Target Name="GetFrameworkPaths" DependsOnTargets="$(GetFrameworkPathsDependsOn)" />
   <Target Name="GetReferenceAssemblyPaths" DependsOnTargets="$(GetReferenceAssemblyPathsDependsOn)" />
 
-  <Import Project="$(CustomAfterCargo)"
-    Condition="'$(CustomAfterCargo)' != '' and Exists('$(CustomAfterCargo)')" />
+  <Import Project="$(CustomAfterCargo)" Condition="'$(CustomAfterCargo)' != '' and Exists('$(CustomAfterCargo)')" />
 
   <!-- 
-    Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and
-  above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
+    Microsoft.Managed.Targets is imported by the managed language target files in MSBuild 16.0 and above, but most of the msbuild tasks are actually in Microsoft.Common.Currentversion.targets.
     So import it when the managed targets do not get imported.
   -->
-  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets"
-    Condition="'$(MSBuildAssemblyVersion)' >= '16.0' And '$(ManagedLanguageTargetsGotImported)' != 'true'" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.Managed.targets" Condition="'$(MSBuildAssemblyVersion)' >= '16.0' And '$(ManagedLanguageTargetsGotImported)' != 'true'" />
 
   <!-- Override stock CoreCompile target to do nothing but keep extensibility points -->
   <Target Name="CoreCompile"
-    DependsOnTargets="$(CoreCompileDependsOn)">
-    <CallTarget Targets="$(TargetsTriggeredByCompilation)"
-      Condition="'$(TargetsTriggeredByCompilation)' != ''" />
+      DependsOnTargets="$(CoreCompileDependsOn)">
+    <CallTarget Targets="$(TargetsTriggeredByCompilation)" Condition="'$(TargetsTriggeredByCompilation)' != ''" />
   </Target>
 
   <Target Name="_GenerateCompileInputs" />
   <Target Name="_GenerateCompileDependencyCache" />
 
-  <!-- Disables the _CopyFilesMarkedCopyLocal target to not copy references when
-  SkipCopyFilesMarkedCopyLocal is set to true. -->
-  <Import Project="DisableCopyFilesMarkedCopyLocal.targets"
-    Condition="'$(SkipCopyFilesMarkedCopyLocal)' == 'true'" />
+  <!-- Disables the _CopyFilesMarkedCopyLocal target to not copy references when SkipCopyFilesMarkedCopyLocal is set to true. -->
+  <Import Project="DisableCopyFilesMarkedCopyLocal.targets" Condition="'$(SkipCopyFilesMarkedCopyLocal)' == 'true'" />
   <!-- Rust specific targets -->
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
-    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll"
-    Condition="'$(MSBuildRuntimeType)' == 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
-  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask"
-    AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll"
-    Condition="'$(MSBuildRuntimeType)' != 'Core' And '$(ShouldImportSdkDll)' != 'false'" />
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
+  <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
   <Target Name="CargoInstall" AfterTargets="_CollectRestoreInputs">
     <MSBuild
-      Projects="$(MSBuildThisFileDirectory)CargoInstall.proj"
-      Targets="CargoInstall"
-      Properties="EnableTelemetryLoggerCopy=$(EnableTelemetryLoggerCopy);TelemetryLoggerLocation=$(TelemetryLoggerLocation);TelemetryLoggerSourcePath=$(TelemetryLoggerSourcePath);TelemetryLoggerInstallId=$(TelemetryLoggerInstallId)"
-      RemoveProperties="NuGetInteractive;MSBuildRestoreSessionId;TargetFramework;RuntimeIdentifier" />
+       Projects="$(MSBuildThisFileDirectory)CargoInstall.proj"
+       Targets="CargoInstall"
+       Properties="EnableTelemetryLoggerCopy=$(EnableTelemetryLoggerCopy);TelemetryLoggerLocation=$(TelemetryLoggerLocation);TelemetryLoggerSourcePath=$(TelemetryLoggerSourcePath);TelemetryLoggerInstallId=$(TelemetryLoggerInstallId)"
+       RemoveProperties="NuGetInteractive;MSBuildRestoreSessionId;TargetFramework;RuntimeIdentifier" />
   </Target>
   <Target Name="CargoFetch" AfterTargets="CargoInstall">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="fetch"
-      UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="fetch" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="CargoBuild" AfterTargets="CoreCompile" DependsOnTargets="CargoFetch">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build"
-      CommandArgs="$(BuildCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build" CommandArgs="$(BuildCommandArgs)" UseMsRustUp="$(UseMsRustUp)"  />
   </Target>
   <Target Name="Test" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(TestCommandArgs)"
-      UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(TestCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Clean">
-    <CargoTask StartupProj="$(StartupProj)" Command="clean" CommandArgs="$(CleanCommandArgs)"
-      UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="clean" CommandArgs="$(CleanCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Run" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(StartupProj)" Command="run" CommandArgs="$(RunCommandArgs)"
-      UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="run" CommandArgs="$(RunCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="Doc" DependsOnTargets="Cargo">
-    <CargoTask StartupProj="$(StartupProj)" Command="doc" CommandArgs="$(DocCommandArgs)"
-      UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="doc" CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
   <Target Name="ClearCargoCache">
-    <CargoTask StartupProj="$(StartupProj)" Command="clearcargocache"
-      CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="clearcargocache" CommandArgs="$(DocCommandArgs)" UseMsRustUp="$(UseMsRustUp)" />
   </Target>
 </Project>


### PR DESCRIPTION
This change updates the sdk to ensure that cargo and rust, are installed exactly once. It also adds further support for msrustup auth with the addition of the msrustup_file env var