### PR TITLE
Cleanup a few properties from Directory.Build.props

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <UseArtifactsOutput>false</UseArtifactsOutput>
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('UnitTests'))">true</IsTestProject>
     <IsPackable Condition="'$(IsTestProject)' != 'true'">true</IsPackable>
-    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <UseArtifactsOutput>false</UseArtifactsOutput>
 
     <!-- Suppress spam about using a preview version of .NET -->

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <UseArtifactsOutput>false</UseArtifactsOutput>
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('UnitTests'))">true</IsTestProject>
     <IsPackable Condition="'$(IsTestProject)' != 'true'">true</IsPackable>
-    <UseArtifactsOutput>false</UseArtifactsOutput>
 
     <!-- Suppress spam about using a preview version of .NET -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
 
     <!-- Please use caution adding a dependency to MSBuild packages. Use latest for testing and
          use the minimum version for compilation for back compat. -->


### PR DESCRIPTION
Simple cleanup I noticed when reviewing other changes.

- Move CPM transitive pinning to Directory.Packages.props
- Remove duplicate definition of UseArtifactsOutput