### PR TITLE
RunVSTest: Fix VSTestSetting and VSTestListTests properties

### DIFF
--- a/src/RunTests/RunVSTestTask.cs
+++ b/src/RunTests/RunVSTestTask.cs
@@ -168,7 +168,7 @@ namespace Microsoft.Build
             if (!string.IsNullOrEmpty(VSTestSetting))
             {
                 isRunSettingsEnabled = true;
-                commandLineBuilder.AppendSwitchIfNotNull("--settings", VSTestSetting);
+                commandLineBuilder.AppendSwitchIfNotNull("--settings:", VSTestSetting);
             }
 
             if (VSTestTestAdapterPath != null && VSTestTestAdapterPath.Length > 0)
@@ -215,7 +215,7 @@ namespace Microsoft.Build
 
             if (!string.IsNullOrEmpty(VSTestListTests))
             {
-                commandLineBuilder.AppendSwitchIfNotNull("--listTests", VSTestListTests);
+                commandLineBuilder.AppendSwitchIfNotNull("--listTests:", VSTestListTests);
             }
 
             if (!string.IsNullOrEmpty(VSTestDiag))


### PR DESCRIPTION
RunVSTest: Fix VSTestSetting and VSTestListTests properties

These properties map to command-line args to vstest.console, but the `:` is missing in these two cases. This leads to errors like:

```
The argument --settingsD:\a\_work\1\s\build\build\xunit.runsettings is invalid. Please use the /help option to check the list of valid arguments.
```