### PR TITLE
Add Microsoft.Build.UniversalPackages

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="CopyOnWrite" Version="0.5.0" Condition=" '$(TargetFramework)' != 'net46' " />
+    <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />

--- a/MSBuildSdks.sln
+++ b/MSBuildSdks.sln
@@ -90,6 +90,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Cargo", "sr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.Cargo.UnitTests", "src\Cargo.UnitTests\Microsoft.Build.Cargo.UnitTests.csproj", "{D6EF1644-D06C-4877-A8F7-3543E5D3175B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Build.UniversalPackages", "src\UniversalPackages\Microsoft.Build.UniversalPackages.csproj", "{D60201AA-45FE-4F15-BEDE-356BBDCA4E2F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -164,6 +166,10 @@ Global
 		{D6EF1644-D06C-4877-A8F7-3543E5D3175B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D6EF1644-D06C-4877-A8F7-3543E5D3175B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6EF1644-D06C-4877-A8F7-3543E5D3175B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D60201AA-45FE-4F15-BEDE-356BBDCA4E2F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D60201AA-45FE-4F15-BEDE-356BBDCA4E2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D60201AA-45FE-4F15-BEDE-356BBDCA4E2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D60201AA-45FE-4F15-BEDE-356BBDCA4E2F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/UniversalPackages/DownloadUniversalPackages.cs
+++ b/src/UniversalPackages/DownloadUniversalPackages.cs
@@ -1,0 +1,837 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+namespace Microsoft.Build.UniversalPackages;
+
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+#if NETFRAMEWORK
+using System.Net;
+#else
+using System.Net.Http.Headers;
+#endif
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
+using Microsoft.Build.Definition;
+using Microsoft.Build.Evaluation;
+using Microsoft.Build.Evaluation.Context;
+using Microsoft.Build.Execution;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Graph;
+using Microsoft.Build.Utilities;
+
+/// <summary>
+/// Downloads a universal package.
+/// </summary>
+public sealed class DownloadUniversalPackages : Task
+{
+    private const string PackageItemName = "UniversalPackage";
+
+    private const string CredentialProviderRelativePath = @"plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe";
+
+    private const string PatVarNameBase = "ArtifactToolPat_";
+
+    /// <summary>
+    /// Gets or sets the currently building project file path.
+    /// </summary>
+    [Required]
+    public string ProjectFile { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the Azure DevOps account name to use.
+    /// </summary>
+    [Required]
+    public string AccountName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the path to the artifacts credential provider.
+    /// </summary>
+    [Required]
+    public string ArtifactsCredentialProviderPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the base path.
+    /// </summary>
+    [Required]
+    public string ArtifactToolBasePath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the root path to install packages.
+    /// </summary>
+    [Required]
+    public string UniversalPackagesRootPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the path to use for the intermediate package list json file used for batch downloading.
+    /// </summary>
+    [Required]
+    public string PackageListJsonPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the an override to the ArtifactTool executable path.
+    /// </summary>
+    public string? ArtifactToolPath { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for the ArtifactTool OS name.
+    /// </summary>
+    public string? ArtifactToolOsName { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for the ArtifactTool arch.
+    /// </summary>
+    public string? ArtifactToolArch { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for the ArtifactTool distro name.
+    /// </summary>
+    public string? ArtifactToolDistroName { get; set; }
+
+    /// <summary>
+    /// Gets or sets an override for the ArtifactTool distro version.
+    /// </summary>
+    public string? ArtifactToolDistroVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the environment variable which contains credentials to use.
+    /// </summary>
+    public string? PatVar { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the credential provider should run in interactive mode.
+    /// </summary>
+    public bool Interactive { get; set; }
+
+    /// <summary>
+    /// Gets or sets the directory of a cache to store downloaded files. If unspecified, then the cache is disabled.
+    /// </summary>
+    public string? CacheDirectory { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether special file(s)/folder(s) are NOT to be ignored during a drop upload. E.g.,'.git' folder will NOT be ignored when this is passed.
+    /// </summary>
+    public bool IgnoreNothing { get; set; }
+
+    /// <summary>
+    /// Gets or sets the verbosity of logging.
+    /// </summary>
+    public string? Verbosity { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to use local time for logging. Otherwise UTC time.
+    /// </summary>
+    public bool UseLocalTime { get; set; } = true;
+
+    /// <inheritdoc />
+    public override bool Execute()
+    {
+        string universalPackagesRootPath = Path.GetFullPath(UniversalPackagesRootPath);
+        IReadOnlyCollection<UniversalPackage> packages = GetPackagesToDownload(universalPackagesRootPath);
+        if (Log.HasLoggedErrors)
+        {
+            // Don't continue downloading if errors were logged
+            return false;
+        }
+
+        if (packages.Count == 0)
+        {
+            Log.LogMessage(MessageImportance.Normal, "No Universal Packages to download.");
+            return true;
+        }
+
+        // Batch downloads are more efficient, so generate the required json file.
+        string packageListJsonPath = Path.GetFullPath(PackageListJsonPath);
+        CreatePackageListJson(packages, packageListJsonPath);
+
+        string? patVar = GetPatVar();
+        if (string.IsNullOrWhiteSpace(patVar))
+        {
+            return false;
+        }
+
+        string? artifactToolPath = GetArtifactToolPath(patVar!);
+        if (string.IsNullOrWhiteSpace(artifactToolPath))
+        {
+            return false;
+        }
+
+        bool downloadResult = BatchDownloadUniversalPackages(packageListJsonPath, artifactToolPath!, patVar!);
+        if (!downloadResult)
+        {
+            return false;
+        }
+
+        return !Log.HasLoggedErrors;
+    }
+
+    private IReadOnlyCollection<UniversalPackage> GetPackagesToDownload(string universalPackagesRootPath)
+    {
+        Stopwatch stopwatch = Stopwatch.StartNew();
+
+        Dictionary<string, string> globalProperties = BuildEngine6.GetGlobalProperties()
+            .ToDictionary(kvp => kvp.Key, kvp => kvp.Value, StringComparer.OrdinalIgnoreCase);
+
+        var evaluationContext = EvaluationContext.Create(EvaluationContext.SharingPolicy.Shared);
+
+        // Ignore bad imports to maximize the chances of being able to load the project and restore
+        ProjectLoadSettings loadSettings = ProjectLoadSettings.IgnoreEmptyImports | ProjectLoadSettings.IgnoreInvalidImports | ProjectLoadSettings.IgnoreMissingImports | ProjectLoadSettings.DoNotEvaluateElementsWithFalseCondition;
+
+        var graph = new ProjectGraph(
+            [new ProjectGraphEntryPoint(ProjectFile, globalProperties)],
+            ProjectCollection.GlobalProjectCollection,
+            (string projectPath, Dictionary<string, string> globalProperties, ProjectCollection projCollection) =>
+            {
+                var projectOptions = new ProjectOptions
+                {
+                    GlobalProperties = globalProperties,
+                    ToolsVersion = projCollection.DefaultToolsVersion,
+                    ProjectCollection = projCollection,
+                    LoadSettings = loadSettings,
+                    EvaluationContext = evaluationContext,
+                };
+
+                return ProjectInstance.FromFile(projectPath, projectOptions);
+            });
+
+        Log.LogMessage(
+            MessageImportance.Low,
+            $"Static graph loaded in {graph.ConstructionMetrics.ConstructionTime.TotalSeconds:F3} seconds: {graph.ConstructionMetrics.NodeCount} nodes, {graph.ConstructionMetrics.EdgeCount} edges");
+
+        // Use a set to deduplicate exact matches
+        var packages = new HashSet<UniversalPackage>();
+        foreach (ProjectGraphNode node in graph.ProjectNodes)
+        {
+            foreach (ProjectItemInstance packageItem in node.ProjectInstance.GetItems(PackageItemName))
+            {
+                string name = packageItem.EvaluatedInclude;
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    Log.LogError($"Universal Package name was empty (project '{node.ProjectInstance.FullPath}')");
+                    continue;
+                }
+
+                string version = packageItem.GetMetadataValue("Version");
+                if (string.IsNullOrWhiteSpace(version))
+                {
+                    Log.LogError($"Universal Package '{name}' was missing a version (project '{node.ProjectInstance.FullPath}')");
+                    continue;
+                }
+
+                string? project = packageItem.GetMetadataValue("Project");
+                if (string.IsNullOrWhiteSpace(project))
+                {
+                    project = null;
+                }
+
+                string feed = packageItem.GetMetadataValue("Feed");
+                if (string.IsNullOrWhiteSpace(feed))
+                {
+                    Log.LogError($"Universal Package '{name}' was missing a feed name (project '{node.ProjectInstance.FullPath}')");
+                    continue;
+                }
+
+                string path = packageItem.GetMetadataValue("Path");
+                if (string.IsNullOrWhiteSpace(path))
+                {
+                    path = Path.Combine(universalPackagesRootPath, $"{name}.{version}");
+                }
+                else if (!Path.IsPathRooted(path))
+                {
+                    path = Path.Combine(node.ProjectInstance.Directory, path);
+                }
+
+                string? filter = packageItem.GetMetadataValue("Filter");
+                if (string.IsNullOrWhiteSpace(filter))
+                {
+                    filter = null;
+                }
+
+                var package = new UniversalPackage(project, feed, name, version, path, filter);
+                packages.Add(package);
+            }
+        }
+
+        // Validate Paths are either unique so downloads don't stomp on each other. ArtifactTool doesn't do this for us, but probably should, especially since it downloads them in parallel.
+        var downloadPaths = new Dictionary<string, UniversalPackage>(PathHelper.PathComparer);
+        foreach (UniversalPackage package in packages)
+        {
+            if (downloadPaths.TryGetValue(package.Path, out UniversalPackage? existingPackage))
+            {
+                Log.LogError($"Found multiple universal package download requests to the same path: {package.Path}. Packages '{existingPackage.PackageName} {existingPackage.PackageVersion}' and '{package.PackageName}.{package.PackageVersion}'");
+            }
+            else
+            {
+                downloadPaths.Add(package.Path, package);
+            }
+        }
+
+        return packages;
+    }
+
+    private void CreatePackageListJson(IReadOnlyCollection<UniversalPackage> packages, string packageListJsonPath)
+    {
+        var batchRequest = new UniversalPackageBatchDownloadRequest(packages);
+        var options = new JsonSerializerOptions()
+        {
+            // Avoid writing unecessary values.
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+
+            // Make human-readable for easier debugging
+            WriteIndented = true,
+        };
+        string? packageListJsonDir = Path.GetDirectoryName(packageListJsonPath);
+        if (!string.IsNullOrEmpty(packageListJsonDir))
+        {
+            Directory.CreateDirectory(packageListJsonDir);
+        }
+
+        using (FileStream fileStream = File.Create(packageListJsonPath))
+        {
+            JsonSerializer.Serialize(fileStream, batchRequest, options);
+        }
+    }
+
+    private string? GetArtifactToolPath(string patVar)
+    {
+        if (!string.IsNullOrWhiteSpace(ArtifactToolPath))
+        {
+            // Allow the user to specify either the exe or the dir
+            if (File.Exists(ArtifactToolPath))
+            {
+                return ArtifactToolPath;
+            }
+
+            if (Directory.Exists(ArtifactToolPath))
+            {
+                return GetArtifactToolExePath(ArtifactsCredentialProviderPath);
+            }
+
+            Log.LogError($"ArtifactTool path '{ArtifactToolPath}' does not exist.");
+            return null;
+        }
+
+        string artifactToolOsName;
+        if (!string.IsNullOrWhiteSpace(ArtifactToolOsName))
+        {
+            artifactToolOsName = ArtifactToolOsName!;
+        }
+        else
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                artifactToolOsName = "windows";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                artifactToolOsName = "linux";
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                artifactToolOsName = "darwin";
+            }
+            else
+            {
+                throw new NotSupportedException($"Unsupported OS: {RuntimeInformation.OSDescription}");
+            }
+        }
+
+        string? artifactToolArch;
+        if (!string.IsNullOrEmpty(ArtifactToolArch))
+        {
+            artifactToolArch = ArtifactToolArch!;
+        }
+        else
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                artifactToolArch = Environment.GetEnvironmentVariable("PROCESSOR_ARCHITECTURE")?.ToLowerInvariant();
+                if (string.IsNullOrEmpty(artifactToolArch))
+                {
+                    Log.LogError("Environment variable 'PROCESSOR_ARCHITECTURE' was unexpectedly null");
+                    return null;
+                }
+            }
+            else
+            {
+                // This isn' quite right. Really we want to use "uname -m" since that's what the artifact tool uses.
+                artifactToolArch = Environment.GetEnvironmentVariable("HOSTTYPE")?.ToLowerInvariant();
+                if (string.IsNullOrEmpty(artifactToolArch))
+                {
+                    Log.LogError("Environment variable 'HOSTTYPE' was unexpectedly null");
+                    return null;
+                }
+            }
+
+            // For M1 macs, there is no version of artifact tool. However, the x86_64 version can run under Rosetta, so we use that instead.
+            if (artifactToolOsName.Equals("darwin", StringComparison.OrdinalIgnoreCase)
+                && (artifactToolArch!.Equals("amd64", StringComparison.OrdinalIgnoreCase) || artifactToolArch.Equals("arm64", StringComparison.OrdinalIgnoreCase)))
+            {
+                artifactToolArch = "x86_64";
+            }
+
+            // Similarly for Windows ARM64 targets there is no version of artifact tool. However, the x86_64 version can run under emulation, so we use that instead.
+            if (artifactToolOsName.Equals("windows", StringComparison.OrdinalIgnoreCase)
+                && artifactToolArch!.Equals("arm64", StringComparison.OrdinalIgnoreCase))
+            {
+                artifactToolArch = "x86_64";
+            }
+        }
+
+        (string Version, string DownloadUri)? releaseInfo = GetArtifactToolReleaseInfo(artifactToolOsName, artifactToolArch!, patVar);
+        if (releaseInfo is null)
+        {
+            return null;
+        }
+
+        string artifactToolPath = Path.Combine(ArtifactToolBasePath, releaseInfo.Value.Version, artifactToolOsName, artifactToolArch);
+        if (!string.IsNullOrWhiteSpace(ArtifactToolDistroName))
+        {
+            artifactToolPath = Path.Combine(artifactToolPath, ArtifactToolDistroName);
+        }
+
+        if (!string.IsNullOrWhiteSpace(ArtifactToolDistroVersion))
+        {
+            artifactToolPath = Path.Combine(artifactToolPath, ArtifactToolDistroVersion);
+        }
+
+        // Download only if needed
+        if (!Directory.Exists(artifactToolPath))
+        {
+            bool downloadResult = DownloadAndExtractArchive("ArtifactTool", releaseInfo.Value.DownloadUri, artifactToolPath, isZip: true);
+            if (!downloadResult)
+            {
+                return null;
+            }
+        }
+
+        return GetArtifactToolExePath(artifactToolPath);
+
+        string? GetArtifactToolExePath(string dir)
+        {
+            string exeName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "artifacttool.exe" : "artifacttool";
+            string exePath = Path.Combine(dir, exeName);
+            if (File.Exists(exePath))
+            {
+                return exePath;
+            }
+
+            Log.LogError($"ArtifactTool '{exePath}' was not found.");
+            return null;
+        }
+    }
+
+    private (string Version, string DownloadUri)? GetArtifactToolReleaseInfo(string osName, string arch, string patVar)
+    {
+        string releaseInfoUrl = GetArtifactToolReleaseInfoUrl(osName, arch);
+        Log.LogMessage($"Fetching ArtifactTool release information from {releaseInfoUrl}");
+
+        // TODO: Currently the release info url unexpectedly requires auth.
+        //       For now just use the versionless download url and a static version number. This means that once downloaded,
+        //       the same version of the tool will be used going forward without any updates.
+        string pat = Environment.GetEnvironmentVariable(patVar) !;
+
+#if NETFRAMEWORK
+        using WebClient webClient = new WebClient();
+        webClient.Headers.Add("Authorization", $"Bearer {pat}");
+        string json = webClient.DownloadString(releaseInfoUrl);
+#else
+        using HttpClient httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", pat);
+        string json = httpClient.GetStringAsync(releaseInfoUrl).GetAwaiter().GetResult();
+#endif
+
+        using JsonDocument jsonDocument = JsonDocument.Parse(json);
+        JsonElement root = jsonDocument.RootElement;
+
+        string? version = root.GetProperty("version").GetString();
+        if (version is null)
+        {
+            Log.LogError($"ArtifactTool release info json was missing the 'version' property. Json content: {json}");
+            return null;
+        }
+
+        string? downloadUri = root.GetProperty("uri").GetString();
+        if (downloadUri is null)
+        {
+            Log.LogError($"ArtifactTool release info json was missing the 'uri' property. Json content: {json}");
+            return null;
+        }
+
+        Log.LogMessage($"Current ArtifactTool version: {version}");
+
+        return (version, downloadUri);
+    }
+
+    private string GetArtifactToolReleaseInfoUrl(string osName, string arch)
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.Append("https://vsblob.dev.azure.com/");
+        sb.Append(AccountName);
+        sb.Append("/_apis/clienttools/artifacttool/release?");
+
+        sb.Append("osName=").Append(osName);
+        sb.Append("&arch=").Append(arch);
+
+        if (!string.IsNullOrWhiteSpace(ArtifactToolDistroName))
+        {
+            sb.Append("&distroName=").Append(ArtifactToolDistroName);
+        }
+
+        if (!string.IsNullOrWhiteSpace(ArtifactToolDistroVersion))
+        {
+            sb.Append("&distroVersion=").Append(ArtifactToolDistroVersion);
+        }
+
+        return sb.ToString();
+    }
+
+    private string? GetPatVar()
+    {
+        if (!string.IsNullOrWhiteSpace(PatVar))
+        {
+            return PatVar;
+        }
+
+        string? credentialProviderPath = GetArtifactsCredentialProviderPath();
+        if (credentialProviderPath is null)
+        {
+            return null;
+        }
+
+        CommandLineBuilder commandLineBuilder = new CommandLineBuilder();
+
+        // The credential provider only accepts urls which look like feeds despite the organization being the only thing that actually matters. So fake a url which looks correct enough.
+        var artifactsCredentialProviderUri = $"https://pkgs.dev.azure.com/{AccountName}/_packaging/feed";
+
+        commandLineBuilder.AppendSwitchIfNotNull("-Uri ", artifactsCredentialProviderUri);
+        if (!Interactive)
+        {
+            commandLineBuilder.AppendSwitch("-NonInteractive");
+        }
+
+        // The default output is human-readable, so make it json so we can parse it.
+        commandLineBuilder.AppendSwitchIfNotNull("-OutputFormat ", "Json");
+
+        // Without this the creds are pulled from the session token cache and may be expired. Force a new token every time.
+        commandLineBuilder.AppendSwitch("-IsRetry");
+
+        string arguments = commandLineBuilder.ToString();
+        Log.LogMessage(MessageImportance.Low, $"Invoking Credential Provider: {credentialProviderPath} {arguments}");
+
+        // The credential provider writes the JSON output to stdout and debugging information to stderr.
+        StringBuilder outputJson = new StringBuilder();
+        int exitCode = ProcessHelper.Execute(
+            credentialProviderPath,
+            arguments,
+            processStdOut: message => outputJson.Append(message),
+            processStdErr: message => Log.LogMessage(MessageImportance.Low, message));
+        if (exitCode != 0)
+        {
+            Log.LogError($"Credential Provider failed with exit code: {exitCode}.");
+            return null;
+        }
+
+        string? pat = null;
+        try
+        {
+            using JsonDocument jsonDocument = JsonDocument.Parse(outputJson.ToString());
+            if (jsonDocument.RootElement.TryGetProperty("Password", out JsonElement passwordElement))
+            {
+                pat = passwordElement.GetString();
+            }
+        }
+        catch (Exception ex)
+        {
+            Log.LogError($"Credential Provider output json could not be parsed.");
+            Log.LogErrorFromException(ex);
+            return null;
+        }
+
+        if (pat is null)
+        {
+            Log.LogError($"Credential Provider output json did not contain a PAT");
+            return null;
+        }
+
+        // Use a somewhat random name to slightly help with predictability.
+        string patVarName = $"{PatVarNameBase}{Guid.NewGuid():N}";
+
+        Environment.SetEnvironmentVariable(patVarName, pat);
+
+        return patVarName;
+    }
+
+    private string? GetArtifactsCredentialProviderPath()
+    {
+        string credentialProviderDir;
+        if (!string.IsNullOrWhiteSpace(ArtifactsCredentialProviderPath))
+        {
+            // Allow the user to specify either the exe or the root dir
+            if (File.Exists(ArtifactsCredentialProviderPath))
+            {
+                return ArtifactsCredentialProviderPath;
+            }
+
+            if (Directory.Exists(ArtifactsCredentialProviderPath))
+            {
+                return GetArtifactsCredentialProviderExePath(ArtifactsCredentialProviderPath);
+            }
+
+            Log.LogError($"Credential provider path '{ArtifactsCredentialProviderPath}' does not exist.");
+            return null;
+        }
+        else
+        {
+            (string Version, string DownloadUri)? releaseInfo = GetArtifactsCredentialProviderReleaseInfo();
+            if (releaseInfo is null)
+            {
+                return null;
+            }
+
+            credentialProviderDir = Path.Combine(ArtifactToolBasePath, "credential-provider", releaseInfo.Value.Version, "plugins", "netcore", "CredentialProvider.Microsoft");
+
+            // Download only if needed
+            if (!Directory.Exists(credentialProviderDir))
+            {
+                bool downloadResult = DownloadAndExtractArchive("Artifacts Credential Provider", releaseInfo.Value.DownloadUri, credentialProviderDir, isZip: RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+                if (!downloadResult)
+                {
+                    return null;
+                }
+            }
+
+            return GetArtifactsCredentialProviderExePath(credentialProviderDir);
+        }
+
+        string? GetArtifactsCredentialProviderExePath(string dir)
+        {
+            string credentialProviderExePath = Path.Combine(dir, CredentialProviderRelativePath);
+            if (File.Exists(credentialProviderExePath))
+            {
+                return credentialProviderExePath;
+            }
+
+            Log.LogError($"Credential provider path '{CredentialProviderRelativePath}' was not found under '{dir}'.");
+            return null;
+        }
+    }
+
+    private (string Version, string DownloadUri)? GetArtifactsCredentialProviderReleaseInfo()
+    {
+        const string ReleaseInfoUrl = "https://api.github.com/repos/Microsoft/artifacts-credprovider/releases/latest";
+#if NETFRAMEWORK
+        using WebClient webClient = new WebClient();
+        webClient.Headers.Add("User-Agent", "Microsoft.Build.UniversalPackages"); // GitHub API requires a user agent header
+        string json = webClient.DownloadString(ReleaseInfoUrl);
+#else
+        using HttpClient httpClient = new HttpClient();
+        httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Microsoft.Build.UniversalPackages"));
+        string json = httpClient.GetStringAsync(ReleaseInfoUrl).GetAwaiter().GetResult();
+#endif
+
+        using JsonDocument jsonDocument = JsonDocument.Parse(json);
+        JsonElement root = jsonDocument.RootElement;
+
+        string? version = root.GetProperty("name").GetString();
+        if (version is null)
+        {
+            Log.LogError($"Artifacts Credential Provider release info json was missing the 'name' property. Json content: {json}");
+            return null;
+        }
+
+        Log.LogMessage($"Current Artifacts Credential Provider version: {version}");
+
+        string rid;
+        string fileExtension;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            rid = "win-x64";
+            fileExtension = ".zip";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            rid = RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "linux-arm64"
+                : "linux-x64";
+            fileExtension = ".tar.gz";
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            rid = RuntimeInformation.ProcessArchitecture == Architecture.Arm64
+                ? "osx-arm64"
+                : "osx-x64";
+            fileExtension = ".tar.gz";
+        }
+        else
+        {
+            Log.LogError($"Could not determine correct runtime to download the Artifact Credential Provider.");
+            return null;
+        }
+
+        string fileNamePattern = $@"Microsoft.Net(\d+).{rid}.NuGet.CredentialProvider{fileExtension}";
+        Log.LogMessage(MessageImportance.Low, $"Looking for Artifacts Credential Provider asset with name: {fileNamePattern}");
+        Regex fileNameRegex = new Regex(fileNamePattern, RegexOptions.IgnoreCase);
+
+        int maxNetVersion = 0;
+        string? maxVersionDownloadUrl = null;
+        foreach (JsonElement asset in root.GetProperty("assets").EnumerateArray())
+        {
+            string? assetName = asset.GetProperty("name").GetString();
+            if (assetName is null)
+            {
+                continue;
+            }
+
+            Match match = fileNameRegex.Match(assetName);
+            if (!match.Success)
+            {
+                continue;
+            }
+
+            string netVersionStr = match.Groups[1].Value;
+            if (!int.TryParse(netVersionStr, out int netVersion))
+            {
+                continue;
+            }
+
+            if (netVersion > maxNetVersion)
+            {
+                maxNetVersion = netVersion;
+                maxVersionDownloadUrl = asset.GetProperty("browser_download_url").GetString();
+            }
+        }
+
+        if (maxVersionDownloadUrl is null)
+        {
+            Log.LogError($"Unable to find a download url for the Artifact Credential Provider.");
+            return null;
+        }
+
+        string downloadUri = maxVersionDownloadUrl;
+
+        return (version, downloadUri);
+    }
+
+    private bool DownloadAndExtractArchive(string displayName, string downloadUri, string path, bool isZip)
+    {
+        string? archiveDownloadPath = null;
+        string? archiveExtractPath = null;
+        try
+        {
+            // Download and extract to a temporary location and finally move the directory to make the operation atomic.
+            string downloadDir = Path.Combine(ArtifactToolBasePath, ".tmp");
+            Directory.CreateDirectory(downloadDir);
+
+            archiveDownloadPath = Path.Combine(downloadDir, Path.GetRandomFileName()) + (isZip ? ".zip" : ".tar.gz");
+            Log.LogMessage(MessageImportance.Low, $"Downloading {displayName} from {downloadUri} to {archiveDownloadPath}");
+#if NETFRAMEWORK
+            using WebClient webClient = new WebClient();
+            webClient.DownloadFile(downloadUri, archiveDownloadPath);
+#else
+            using HttpClient httpClient = new HttpClient();
+            using (FileStream archiveFileStream = File.Create(archiveDownloadPath))
+            {
+                httpClient.GetStreamAsync(downloadUri).GetAwaiter().GetResult().CopyTo(archiveFileStream);
+            }
+#endif
+            Log.LogMessage(MessageImportance.Low, $"Downloaded {displayName}");
+
+            archiveExtractPath = Path.Combine(downloadDir, Path.GetRandomFileName());
+            Log.LogMessage(MessageImportance.Low, $"Extracting {displayName} from {archiveDownloadPath} to {archiveExtractPath}");
+            if (isZip)
+            {
+                ZipFile.ExtractToDirectory(archiveDownloadPath, archiveExtractPath);
+            }
+            else
+            {
+                // There is no built-in support for extracting tar.gz files, so fall back to the tar command.
+                int exitCode = ProcessHelper.Execute(
+                    "/bin/bash",
+                    $"tar -xzf \"{archiveDownloadPath}\" -C \"{archiveExtractPath}\"",
+                    processStdOut: message => Log.LogMessage(MessageImportance.Low, message),
+                    processStdErr: message => Log.LogError(message));
+                if (exitCode != 0)
+                {
+                    Log.LogError($"Extracting Artifacts Credential Provider failed with exit code: {exitCode}");
+                    return false;
+                }
+            }
+
+            Log.LogMessage(MessageImportance.Low, "Extracted Artifacts Credential Provider");
+
+            DirectoryInfo destination = new DirectoryInfo(path);
+            if (destination.Exists)
+            {
+                destination.Delete(true);
+            }
+
+            destination.Parent?.Create();
+            Directory.Move(archiveExtractPath, destination.FullName);
+
+            return true;
+        }
+        finally
+        {
+            if (File.Exists(archiveDownloadPath))
+            {
+                File.Delete(archiveDownloadPath);
+            }
+
+            if (Directory.Exists(archiveExtractPath))
+            {
+                Directory.Delete(archiveExtractPath, true);
+            }
+        }
+    }
+
+    private bool BatchDownloadUniversalPackages(string packageListJsonPath, string artifactToolPath, string patVar)
+    {
+        CommandLineBuilder commandLineBuilder = new CommandLineBuilder();
+
+        commandLineBuilder.AppendSwitch("universal");
+        commandLineBuilder.AppendSwitch("batch-download");
+
+        commandLineBuilder.AppendSwitchIfNotNull("--service ", $"https://dev.azure.com/{AccountName}");
+        commandLineBuilder.AppendSwitchIfNotNull("--patvar ", patVar);
+
+        if (IgnoreNothing)
+        {
+            commandLineBuilder.AppendSwitch("--ignoreNothing");
+        }
+
+        if (!string.IsNullOrWhiteSpace(Verbosity))
+        {
+            commandLineBuilder.AppendSwitchIfNotNull("--verbosity ", Verbosity);
+        }
+
+        if (UseLocalTime)
+        {
+            commandLineBuilder.AppendSwitch("--use-local-time");
+        }
+
+        if (!string.IsNullOrWhiteSpace(CacheDirectory))
+        {
+            commandLineBuilder.AppendSwitchIfNotNull("--cache-directory ", CacheDirectory);
+        }
+
+        commandLineBuilder.AppendSwitchIfNotNull("--package-list-json ", packageListJsonPath);
+
+        int exitCode = ProcessHelper.Execute(
+            artifactToolPath,
+            commandLineBuilder.ToString(),
+            processStdOut: message => Log.LogMessage(MessageImportance.Low, message),
+            processStdErr: message => Log.LogError(message));
+        if (exitCode != 0)
+        {
+            Log.LogError($"ArtifactTool failed with exit code: {exitCode}.");
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/UniversalPackages/DownloadUniversalPackages.cs
+++ b/src/UniversalPackages/DownloadUniversalPackages.cs
@@ -49,12 +49,6 @@ public sealed class DownloadUniversalPackages : Task
     public string AccountName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets the path to the artifacts credential provider.
-    /// </summary>
-    [Required]
-    public string ArtifactsCredentialProviderPath { get; set; } = string.Empty;
-
-    /// <summary>
     /// Gets or sets the base path.
     /// </summary>
     [Required]
@@ -71,6 +65,11 @@ public sealed class DownloadUniversalPackages : Task
     /// </summary>
     [Required]
     public string PackageListJsonPath { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the path to the artifacts credential provider.
+    /// </summary>
+    public string? ArtifactsCredentialProviderPath { get; set; }
 
     /// <summary>
     /// Gets or sets the an override to the ArtifactTool executable path.
@@ -308,7 +307,7 @@ public sealed class DownloadUniversalPackages : Task
 
             if (Directory.Exists(ArtifactToolPath))
             {
-                return GetArtifactToolExePath(ArtifactsCredentialProviderPath);
+                return GetArtifactToolExePath(ArtifactToolPath!);
             }
 
             Log.LogError($"ArtifactTool path '{ArtifactToolPath}' does not exist.");
@@ -579,7 +578,7 @@ public sealed class DownloadUniversalPackages : Task
 
             if (Directory.Exists(ArtifactsCredentialProviderPath))
             {
-                return GetArtifactsCredentialProviderExePath(ArtifactsCredentialProviderPath);
+                return GetArtifactsCredentialProviderExePath(ArtifactsCredentialProviderPath!);
             }
 
             Log.LogError($"Credential provider path '{ArtifactsCredentialProviderPath}' does not exist.");

--- a/src/UniversalPackages/DownloadUniversalPackages.cs
+++ b/src/UniversalPackages/DownloadUniversalPackages.cs
@@ -820,11 +820,12 @@ public sealed class DownloadUniversalPackages : Task
 
         commandLineBuilder.AppendSwitchIfNotNull("--package-list-json ", packageListJsonPath);
 
+        // ArtifactTool writes debugging information to stderr.
         int exitCode = ProcessHelper.Execute(
             artifactToolPath,
             commandLineBuilder.ToString(),
             processStdOut: message => Log.LogMessage(MessageImportance.Low, message),
-            processStdErr: message => Log.LogError(message));
+            processStdErr: message => Log.LogMessage(MessageImportance.Low, message));
         if (exitCode != 0)
         {
             Log.LogError($"ArtifactTool failed with exit code: {exitCode}.");

--- a/src/UniversalPackages/Microsoft.Build.UniversalPackages.csproj
+++ b/src/UniversalPackages/Microsoft.Build.UniversalPackages.csproj
@@ -1,0 +1,41 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
+    <Description>Provides targets for downloading universal packages on restore.</Description>
+    <PackageTags>MSBuild MSBuildSdk universalpackages</PackageTags>
+    <ArtifactsPath>$(BaseArtifactsPath)$(MSBuildProjectName)\</ArtifactsPath>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <PackageType>MSBuildSdk</PackageType>
+    <NoDefaultExcludes>true</NoDefaultExcludes>
+    <BuildOutputTargetFolder>tools\</BuildOutputTargetFolder>
+    <DevelopmentDependency>true</DevelopmentDependency>
+    <!-- This package contains MSBuild tasks only, so avoid dependencies. -->
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
+    <OutputFileNamesWithoutVersion>false</OutputFileNamesWithoutVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.HashCode" />
+    <PackageReference Include="Microsoft.Build" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" />
+    <PackageReference Include="System.Text.Json" ExcludeAssets="runtime" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" />
+    <None Include="Sdk\*" />
+  </ItemGroup>
+  <ItemGroup>
+    <FilesToSign Include="$(TargetPath)" Authenticode="Microsoft400" StrongName="StrongName" />
+  </ItemGroup>
+  <Target Name="IncludeReferenceCopyLocalPathsInBuildOutputInPackage"
+          BeforeTargets="_GetBuildOutputFilesWithTfm"
+          DependsOnTargets="ResolveReferences;ResolvePackageDependenciesForBuild">
+    <ItemGroup>
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('AssetType', 'runtime'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+      <BuildOutputInPackage Include="@(RuntimeCopyLocalItems-&gt;WithMetadataValue('CopyLocal', 'true'))"
+                            TargetPath="%(RuntimeCopyLocalItems.DestinationSubDirectory)%(Filename)%(Extension)" />
+    </ItemGroup>
+  </Target>
+</Project>

--- a/src/UniversalPackages/PathHelper.cs
+++ b/src/UniversalPackages/PathHelper.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.Build.UniversalPackages;
+
+internal static class PathHelper
+{
+    public static StringComparer PathComparer { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+}

--- a/src/UniversalPackages/ProcessHelper.cs
+++ b/src/UniversalPackages/ProcessHelper.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+using System.Diagnostics;
+
+namespace Microsoft.Build.UniversalPackages;
+
+/// <summary>
+/// Helper class for executing a process.
+/// </summary>
+internal static class ProcessHelper
+{
+    /// <summary>
+    /// Executes a process and logs the output to the provided TaskLoggingHelper.
+    /// </summary>
+    /// <param name="processName">The name of the process to execute.</param>
+    /// <param name="arguments">The arguments to pass to the process.</param>
+    /// <param name="processStdOut">A delegate to handle standard output.</param>
+    /// <param name="processStdErr">A delegate to handle standard error.</param>
+    /// <returns>The process return code.</returns>
+    public static int Execute(
+        string processName,
+        string arguments,
+        Action<string> processStdOut,
+        Action<string> processStdErr)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+                CreateNoWindow = true,
+                FileName = processName,
+                Arguments = arguments,
+            },
+            EnableRaisingEvents = true,
+        };
+
+        process.OutputDataReceived += (sender, eventArgs) =>
+        {
+            if (eventArgs.Data != null)
+            {
+                processStdOut(eventArgs.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (sender, eventArgs) =>
+        {
+            if (eventArgs.Data != null)
+            {
+                processStdErr(eventArgs.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        process.WaitForExit();
+
+        return process.ExitCode;
+    }
+}

--- a/src/UniversalPackages/README.md
+++ b/src/UniversalPackages/README.md
@@ -1,0 +1,91 @@
+# Microsoft.Build.UniversalPackages
+[![NuGet](https://img.shields.io/nuget/v/Microsoft.Build.UniversalPackages.svg)](https://www.nuget.org/packages/Microsoft.Build.UniversalPackages)
+ [![NuGet](https://img.shields.io/nuget/dt/Microsoft.Build.UniversalPackages.svg)](https://www.nuget.org/packages/Microsoft.Build.UniversalPackages)
+ 
+The `Microsoft.Build.UniversalPackages` MSBuild project SDK allows projects to download [Universal Packages](https://learn.microsoft.com/en-us/azure/devops/artifacts/quickstarts/universal-packages) during MSBuild's Restore target.
+
+The underlying tool this SDK uses to download Universal Packages is called ArtifactTool. By default, this tool is automatically downloaded as needed.
+
+## Example
+
+A basic example is:
+
+In `Directory.Build.props`:
+```xml
+<Project>
+  <Sdk Name="Microsoft.Build.UniversalPackages" />
+  <PropertyGroup>
+    <UniversalPackagesAccountName>SomeAzureDevOpsAccountName</UniversalPackagesAccountName>
+    <UniversalPackagesRootPath>$(MSBuildThisFileDirectory)\packages</UniversalPackagesRootPath>
+  </PropertyGroup>
+</Project>
+```
+
+In a project file:
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <!-- other project content -->
+
+  <ItemGroup>
+    <UniversalPackage Include="SomePackage">
+      <Version>1.0.0</Version>
+      <Feed>SomeFeed</Feed>
+    </UniversalPackage>
+  </ItemGroup>
+</Project>
+```
+
+This will download the package "SomePackage" with version "1.0.0" from organization "SomeAzureDevOpsAccountName" and feed "SomeFeed" to `./packages` (relative to repo root).
+
+The version of `Microsoft.Build.UniversalPackages` should be configured in your `global.json`.
+
+The content of the package can then be consumed by projects from `UniversalPackagesRootPath`.
+
+## Configuration
+
+The `UniversalPackagesAccountName` property is required and must be set to your Azure DevOps account. For example, use "contoso" if you access Azure DevOps via dev.azure.com/contoso
+
+### Authentication
+
+ArtifactTool does not have robust authentication support and must be provided with the name of an environment variable which contains the token to use. This can be configured with the `UniversalPackagesPatVar` property which may need to be used for non-interactive scenarios like CI.
+
+If `UniversalPackagesPatVar` is not provided, the SDK will use the [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) to retrieve an access token.
+
+The `UniversalPackagesInteractiveAuth` property can set to "true" or "false" to enable or disable interactive authentication within the Azure Artifacts Credential Provider. It defaults to "true" unless in a known CI environment.
+
+### `UniversalPackage` Items
+
+Each `UniversalPackage` item represents a package to download.
+
+```xml
+  <ItemGroup>
+    <UniversalPackage Include="PackageA">
+      <Version>1.0.0</Version>
+      <Feed>SomeFeed</Feed>
+    </UniversalPackage>
+    <UniversalPackage Include="PackageB">
+      <Version>2.0.0</Version>
+      <Feed>SomeFeed</Feed>
+    </UniversalPackage>
+  </ItemGroup>
+```
+
+The `Project` item metadata must also be provided for project-scoped feeds.
+
+The `Filter` item metadata can be provided to filter the package contents.
+
+The `Path` item metadata can be provided to specify exactly where to place the package. The default value is `$(UniversalPackagesRootPath)\<package-name>.<package-version>`, where the default value of `$(UniversalPackagesRootPath)` is "packages".
+
+### Advanced configuration
+
+The following properties are available for advanced scenarios but not expected to be set by most end-users:
+
+* The `ArtifactToolPath` property overrides the location of ArtifactTool if downloading the latest version is not desired in favor of some known local copy.
+* The `ArtifactToolBasePath` property configures the location the ArtifactTool is downloaded to. The default is `$(LocalAppData)\ArtifactTool` on Windows or `~/.artifacttool` on Mac/Linux.
+* The `ArtifactToolOsName`, `ArtifactToolArch`, `ArtifactToolDistroName`, and `ArtifactToolDistroVersion` properties override the flavor of ArtifactTool to download.
+* The `UniversalPackageListJsonPath` property configures the path where a temporary package list json files will be created. This file is required for ArtifactTool batch downloads, which are more efficient than sequentially downloading packages. Inspecting this file can be useful for debugging purposes. The default value is `$(BaseIntermediateOutputPath)\universal-packages.json`.
+* The `UniversalPackagesCacheDirectory` property configures the internal cache location used by ArtifactTool. The default is to use `$(ArtifactToolBasePath)/.cache`.
+* The `UniversalPackagesIgnoreNothing` property configures whether special file(s)/folder(s) are *NOT* to be ignored during a drop upload. E.g.,'.git' folder will *NOT* be ignored when this is set.
+* The `UniversalPackagesUseLocalTime` property configures whether to use local time for logging. The default is "true".
+* The `UniversalPackagesVerbosity` property configures the verbosity of logging in the ArtifactTool. Valid values match [`LogLevel`](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel).
+* The `ArtifactsCredentialProviderPath` property overrides the location of the Azure Artifacts Credential Provider if a known local copy is preferred. The default behavior is to attempt to discover an installed version by probing `$(UserProfile)/.nuget/plugins/netfx/CredentialProvider.Microsoft/CredentialProvider.Microsoft.exe` and `$(UserProfile)/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.exe` on Windows or `$(HOME)/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft` on Mac/Linux. If it cannot be found in those locations, the latest version will be downloaded to `$(ArtifactToolBasePath)/credential-provider` if it does not already exist there.

--- a/src/UniversalPackages/Sdk/Sdk.props
+++ b/src/UniversalPackages/Sdk/Sdk.props
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <UsingMicrosoftUniversalPackagesSdk>true</UsingMicrosoftUniversalPackagesSdk>
+  </PropertyGroup>
+
+</Project>

--- a/src/UniversalPackages/Sdk/Sdk.targets
+++ b/src/UniversalPackages/Sdk/Sdk.targets
@@ -1,0 +1,63 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation. All rights reserved.
+  
+  Licensed under the MIT license.
+-->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <UniversalPackagesTaskAssembly Condition="'$(UniversalPackagesTaskAssembly)' == '' and '$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)../tools/net8.0/Microsoft.Build.UniversalPackages.dll</UniversalPackagesTaskAssembly>
+    <UniversalPackagesTaskAssembly Condition="'$(UniversalPackagesTaskAssembly)' == '' and '$(MSBuildRuntimeType)' != 'Core'">$(MSBuildThisFileDirectory)../tools/net472/Microsoft.Build.UniversalPackages.dll</UniversalPackagesTaskAssembly>
+
+    <!-- Base directory where version(s) of the ArtifactTool are downloaded -->
+    <ArtifactToolBasePath Condition="'$(ArtifactToolBasePath)' == '' and $([System.OperatingSystem]::IsWindows())">$(LocalAppData)/ArtifactTool</ArtifactToolBasePath>
+    <ArtifactToolBasePath Condition="'$(ArtifactToolBasePath)' == '' and !$([System.OperatingSystem]::IsWindows())">~/.artifacttool</ArtifactToolBasePath>
+
+    <!--
+      Cache directory for packages.
+      WARNING! Content should not be consumed from this location directly. This property is strictly to configure to internal cache used by ArtifactTool.
+    -->
+    <UniversalPackagesCacheDirectory Condition="'$(UniversalPackagesCacheDirectory)' == ''">$(ArtifactToolBasePath)/.cache</UniversalPackagesCacheDirectory>
+
+    <!-- Enable interactive auth by default, but not when running in a known build environment. -->
+    <UniversalPackagesInteractiveAuth Condition="'$(UniversalPackagesInteractiveAuth)' == '' and '$(TF_BUILD)' != ''">false</UniversalPackagesInteractiveAuth>
+    <UniversalPackagesInteractiveAuth Condition="'$(UniversalPackagesInteractiveAuth)' == ''">true</UniversalPackagesInteractiveAuth>
+
+    <!-- Attempt to use an already-installed cred provider -->
+    <ArtifactsCredentialProviderPath Condition="'$(ArtifactsCredentialProviderPath)' == '' and $([System.OperatingSystem]::IsWindows()) and Exists('$(UserProfile)/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.exe')">$(UserProfile)/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.exe</ArtifactsCredentialProviderPath>
+    <ArtifactsCredentialProviderPath Condition="'$(ArtifactsCredentialProviderPath)' == '' and $([System.OperatingSystem]::IsWindows()) and Exists('$(UserProfile)/.nuget/plugins/netfx/CredentialProvider.Microsoft/CredentialProvider.Microsoft.exe')">$(UserProfile)/.nuget/plugins/netfx/CredentialProvider.Microsoft/CredentialProvider.Microsoft.exe</ArtifactsCredentialProviderPath>
+    <ArtifactsCredentialProviderPath Condition="'$(ArtifactsCredentialProviderPath)' == '' and !$([System.OperatingSystem]::IsWindows()) and Exists('$(HOME)/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft')">$(HOME)/.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft</ArtifactsCredentialProviderPath>
+
+    <!-- Define a default root path for packages -->
+    <UniversalPackagesRootPath Condition="'$(UniversalPackagesPathBase)' == ''">packages</UniversalPackagesRootPath>
+
+    <!-- Path to generate the json file to use for the batch download command -->
+    <UniversalPackageListJsonPath Condition="'$(UniversalPackageListJsonPath)' == ''">$(BaseIntermediateOutputPath)\universal-packages.json</UniversalPackageListJsonPath>
+  </PropertyGroup>
+
+  <UsingTask TaskName="Microsoft.Build.UniversalPackages.DownloadUniversalPackages" AssemblyFile="$(UniversalPackagesTaskAssembly)" />
+
+  <Target Name="DownloadUniversalPackages" AfterTargets="Restore">
+    <DownloadUniversalPackages
+      ProjectFile="$(MSBuildProjectFullPath)"
+      AccountName="$(UniversalPackagesAccountName)"
+      ArtifactsCredentialProviderPath="$(ArtifactsCredentialProviderPath)"
+      ArtifactToolBasePath="$(ArtifactToolBasePath)"
+      UniversalPackagesRootPath="$(UniversalPackagesRootPath)"
+      PackageListJsonPath="$(UniversalPackageListJsonPath)"
+      ArtifactToolPath="$(ArtifactToolPath)"
+      ArtifactToolOsName="$(ArtifactToolOsName)"
+      ArtifactToolArch="$(ArtifactToolArch)"
+      ArtifactToolDistroName="$(ArtifactToolDistroName)"
+      ArtifactToolDistroVersion="$(ArtifactToolDistroVersion)"
+      PatVar="$(UniversalPackagesPatVar)"
+      Interactive="$(UniversalPackagesInteractiveAuth)"
+      CacheDirectory="$(UniversalPackagesCacheDirectory)"
+      IgnoreNothing="$(UniversalPackagesIgnoreNothing)"
+      Verbosity="$(UniversalPackagesVerbosity)"
+      UseLocalTime="$(UniversalPackagesUseLocalTime)"
+      />
+  </Target>
+
+</Project>

--- a/src/UniversalPackages/UniversalPackage.cs
+++ b/src/UniversalPackages/UniversalPackage.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+namespace Microsoft.Build.UniversalPackages;
+
+internal sealed class UniversalPackage : IEquatable<UniversalPackage>
+{
+    public UniversalPackage(string? project, string feed, string packageName, string packageVersion, string path, string? filter)
+    {
+        Project = project;
+        Feed = feed;
+        PackageName = packageName;
+        PackageVersion = packageVersion;
+        Path = path;
+        Filter = filter;
+    }
+
+    public string? Project { get; }
+
+    public string Feed { get; }
+
+    public string PackageName { get; }
+
+    public string PackageVersion { get; }
+
+    public string Path { get; }
+
+    public string? Filter { get; }
+
+    /// <inheritdoc/>
+    public override bool Equals(object? obj) => obj is UniversalPackage other && Equals(other);
+
+    /// <inheritdoc/>
+    public bool Equals(UniversalPackage? other)
+    {
+        if (other is null)
+        {
+            return false;
+        }
+
+        return StringComparer.OrdinalIgnoreCase.Equals(Project, other.Project)
+            && StringComparer.OrdinalIgnoreCase.Equals(Feed, other.Feed)
+            && StringComparer.OrdinalIgnoreCase.Equals(PackageName, other.PackageName)
+            && StringComparer.OrdinalIgnoreCase.Equals(PackageVersion, other.PackageVersion)
+            && PathHelper.PathComparer.Equals(Path, other.Path)
+            && StringComparer.OrdinalIgnoreCase.Equals(Filter, other.Filter);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        HashCode hashCode = default;
+        hashCode.Add(Project ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+        hashCode.Add(Feed, StringComparer.OrdinalIgnoreCase);
+        hashCode.Add(PackageName, StringComparer.OrdinalIgnoreCase);
+        hashCode.Add(PackageVersion, StringComparer.OrdinalIgnoreCase);
+        hashCode.Add(Path, PathHelper.PathComparer);
+        hashCode.Add(Filter ?? string.Empty, StringComparer.OrdinalIgnoreCase);
+        return hashCode.ToHashCode();
+    }
+}

--- a/src/UniversalPackages/UniversalPackageBatchDownloadRequest.cs
+++ b/src/UniversalPackages/UniversalPackageBatchDownloadRequest.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+namespace Microsoft.Build.UniversalPackages;
+
+internal sealed class UniversalPackageBatchDownloadRequest
+{
+    public UniversalPackageBatchDownloadRequest(IReadOnlyCollection<UniversalPackage> requests)
+    {
+        Requests = requests;
+    }
+
+    public IReadOnlyCollection<UniversalPackage> Requests { get; }
+}

--- a/src/UniversalPackages/version.json
+++ b/src/UniversalPackages/version.json
@@ -1,0 +1,4 @@
+﻿{
+  "inherit": true,
+  "version": "1.0"
+}


### PR DESCRIPTION
Introduces a new `Microsoft.Build.UniversalPackages` SDK which allows projects to download [Universal Packages](https://learn.microsoft.com/en-us/azure/devops/artifacts/quickstarts/universal-packages) during MSBuild's Restore target.

There's quite a bit going on here so here's the gist:
* There are 2 mechanisms to configure packages to download: `@(UniversalPackage)` items or `universal-packages.json` package list files
* Unless overridden, the ArtifactTool will be downloaded and executed to download the configured packages
* ArtifactTool unfortunately requires an auth token to be provided by env var. If the name of the env var is provided, eg in CI scenarios, that one is used. Otherwise:
  * The [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) is used to retrieve an auth token which is set in an env var.
  * Unless overridden, the Azure Artifacts Credential Provider will be discovered in the well-known install locations on disk or if needed the latest will be downloaded.