### PR TITLE
Adding an item list with the list of copied files from CopyArtifacts target

### DIFF
--- a/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
+++ b/src/Artifacts.UnitTests/CustomProjectCreatorTemplates.cs
@@ -44,6 +44,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     string artifactsPath = null,
                     string targetFramework = "net472",
                     bool? appendTargetFrameworkToOutputPath = true,
+                    string copiedArtifactsItemName = null,
                     Action<ProjectCreator> customAction = null,
                     string path = null,
                     string defaultTargets = null,
@@ -70,6 +71,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
                 .Property("AppendTargetFrameworkToOutputPath", appendTargetFrameworkToOutputPath.HasValue ? appendTargetFrameworkToOutputPath.ToString() : null)
                 .Property("OutputPath", $"$(OutputPath)$(TargetFramework.ToLowerInvariant()){Path.DirectorySeparatorChar}", condition: "'$(AppendTargetFrameworkToOutputPath)' == 'true'")
                 .Property("ArtifactsPath", artifactsPath)
+                .Property("ArtifactsCopiedFilesItemName", copiedArtifactsItemName)
                 .CustomAction(customAction)
                 .Target("Build")
                 .Target("AfterBuild", afterTargets: "Build")

--- a/src/Artifacts.UnitTests/RobocopyTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyTests.cs
@@ -826,7 +826,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
         }
 
         [Fact]
-        public void CheckCopiedFilesIsEmptyByDefault()
+        public void ListCopiedFilesIsOffByDefault()
         {
             DirectoryInfo source = CreateFiles("source", "bar.txt");
 
@@ -854,7 +854,7 @@ namespace Microsoft.Build.Artifacts.UnitTests
         }
 
         [Fact]
-        public void CheckCopiedFilesIsSetWhenListCopiedFilesIsTrue()
+        public void ListCopiedFilesCanBeEnabled()
         {
             DirectoryInfo source = CreateFiles(
                 "source",

--- a/src/Artifacts.UnitTests/RobocopyTests.cs
+++ b/src/Artifacts.UnitTests/RobocopyTests.cs
@@ -825,6 +825,70 @@ namespace Microsoft.Build.Artifacts.UnitTests
                     customMessage: buildEngine.GetConsoleLog());
         }
 
+        [Fact]
+        public void CheckCopiedFilesIsEmptyByDefault()
+        {
+            DirectoryInfo source = CreateFiles("source", "bar.txt");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            Robocopy copyArtifacts = new ()
+            {
+                BuildEngine = buildEngine,
+                Sources =
+                [
+                    new MockTaskItem(source.FullName)
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                        [nameof(RobocopyMetadata.IsRecursive)] = "false",
+                    },
+                ],
+                Sleep = _ => { },
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(1);
+
+            copyArtifacts.CopiedFiles.Length.ShouldBe(0);
+        }
+
+        [Fact]
+        public void CheckCopiedFilesIsSetWhenListCopiedFilesIsTrue()
+        {
+            DirectoryInfo source = CreateFiles(
+                "source",
+                "bar.txt",
+                "foo.txt");
+
+            DirectoryInfo destination = new DirectoryInfo(Path.Combine(TestRootPath, "destination"));
+            BuildEngine buildEngine = BuildEngine.Create();
+
+            Robocopy copyArtifacts = new ()
+            {
+                BuildEngine = buildEngine,
+                Sources =
+                [
+                    new MockTaskItem(source.FullName)
+                    {
+                        ["DestinationFolder"] = destination.FullName,
+                        [nameof(RobocopyMetadata.IsRecursive)] = "false",
+                    },
+                ],
+                ListCopiedFiles = true,
+                Sleep = _ => { },
+            };
+
+            copyArtifacts.Execute().ShouldBeTrue(buildEngine.GetConsoleLog());
+            copyArtifacts.NumFilesCopied.ShouldBe(2);
+
+            copyArtifacts.CopiedFiles.Length.ShouldBe(2);
+            copyArtifacts.CopiedFiles.All(
+                f => new[] { "foo.txt", "bar.txt" }.Any(
+                    fileName => f.ItemSpec == Path.Combine(destination.FullName, fileName)
+                                && f.GetMetadata("SourceFile") == Path.Combine(source.FullName, fileName))).ShouldBeTrue();
+        }
+
         private sealed class MockFileSystem : IFileSystem
         {
             private int _numCloneFileCalls;

--- a/src/Artifacts/README.md
+++ b/src/Artifacts/README.md
@@ -150,6 +150,7 @@ The following properties control artifacts staging:
 | `ArtifactsShowDiagnostics` | Enables additional logging that can be used to troubleshoot why artifacts are not being staged | `false` |
 | `ArtifactsShowErrorOnRetry` | Logs an error if a retry was attempted.  Disable this to suppress issues while copying files | `true` |
 | `DisableCopyOnWrite` | Disables use of copy-on-write links (file cloning) even if the filesystem allows it. | `false` |
+| `ArtifactsCopiedFiles` | Specifies the name of the item list set with the files copied during CopyArtifacts target run. | |
 | `CustomBeforeArtifactsProps ` | A list of custom MSBuild projects to import **before** artifacts properties are declared. |
 | `CustomAfterArtifactsProps` | A list of custom MSBuild projects to import **after** Artifacts properties are declared.|
 | `CustomBeforeArtifactsTargets` | A list of custom MSBuild projects to import **before** Artifacts targets are declared.|
@@ -162,6 +163,19 @@ To change the default file match for artifacts, set the `DefaultArtifactsFileMat
 <PropertyGroup>
   <DefaultArtifactsFileMatch>*exe *dll *exe.config *.ini *.xml</DefaultArtifactsFileMatch>
 </PropertyGroup>
+```
+
+<br />
+
+To get the list of copied files, set the `ArtifactsCopiedFiles` property:
+```xml
+<PropertyGroup>
+  <ArtifactsCopiedFiles>MyCopiedArtifact</ArtifactsCopiedFiles>
+</PropertyGroup>
+
+<Target Name="DoSomethingWithArtifacts" AfterTargets="CopyArtifacts">
+  <Message Text="Copied %(MyCopiedArtifact.Identity)" />
+</Target>
 ```
 
 <br />

--- a/src/Artifacts/README.md
+++ b/src/Artifacts/README.md
@@ -150,7 +150,7 @@ The following properties control artifacts staging:
 | `ArtifactsShowDiagnostics` | Enables additional logging that can be used to troubleshoot why artifacts are not being staged | `false` |
 | `ArtifactsShowErrorOnRetry` | Logs an error if a retry was attempted.  Disable this to suppress issues while copying files | `true` |
 | `DisableCopyOnWrite` | Disables use of copy-on-write links (file cloning) even if the filesystem allows it. | `false` |
-| `ArtifactsCopiedFiles` | Specifies the name of the item list set with the files copied during CopyArtifacts target run. | |
+| `ArtifactsCopiedFilesItemName` | Specifies an item name which receives the list of files that were copied. | |
 | `CustomBeforeArtifactsProps ` | A list of custom MSBuild projects to import **before** artifacts properties are declared. |
 | `CustomAfterArtifactsProps` | A list of custom MSBuild projects to import **after** Artifacts properties are declared.|
 | `CustomBeforeArtifactsTargets` | A list of custom MSBuild projects to import **before** Artifacts targets are declared.|
@@ -170,11 +170,12 @@ To change the default file match for artifacts, set the `DefaultArtifactsFileMat
 To get the list of copied files, set the `ArtifactsCopiedFiles` property:
 ```xml
 <PropertyGroup>
-  <ArtifactsCopiedFiles>MyCopiedArtifact</ArtifactsCopiedFiles>
+  <ArtifactsCopiedFilesItemName>MyCopiedArtifact</ArtifactsCopiedFilesItemName>
 </PropertyGroup>
 
-<Target Name="DoSomethingWithArtifacts" AfterTargets="CopyArtifacts">
-  <Message Text="Copied %(MyCopiedArtifact.Identity)" />
+<Target Name="LogAllCopiedArtifacts" AfterTargets="CopyArtifacts">
+  <Message Text="Copied @(MyCopiedArtifact->Count()) artifact(s):" />
+  <Message Text="  %(MyCopiedArtifact.Identity)" />
 </Target>
 ```
 

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -7,6 +7,10 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
+    <_ArtifactsListCopiedFiles Condition="'$(ArtifactsCopiedFiles)' != ''">true</_ArtifactsListCopiedFiles>
+    <_RobocopyListCopiedFiles Condition="'$(RobocopyCopiedFiles)' != ''">true</_RobocopyListCopiedFiles>
+    <ArtifactsCopiedFiles Condition="'$(ArtifactsCopiedFiles)' == ''">_</ArtifactsCopiedFiles>
+    <RobocopyCopiedFiles Condition="'$(RobocopyCopiedFiles)' == ''">_</RobocopyCopiedFiles>
   </PropertyGroup>
 
   <UsingTask TaskName="Robocopy"
@@ -34,9 +38,9 @@
       ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(ArtifactsShowErrorOnRetry), 'true'))"
       DisableCopyOnWrite="$([MSBuild]::ValueOrDefault($(DisableCopyOnWrite), 'false'))"
       Sources="@(Artifact)"
-      ListCopiedFiles="$('$(Artifacts_ListCopiedFiles)' == 'true')"
+      ListCopiedFiles="$(_ArtifactsListCopiedFiles)"
       Condition="@(Artifact->Count()) > 0">
-        <Output TaskParameter="CopiedFiles" ItemName="CopyArtifacts_CopiedFiles" />
+        <Output TaskParameter="CopiedFiles" ItemName="$(ArtifactsCopiedFiles)" Condition="'$(_ArtifactsListCopiedFiles)' != 'true'" />
       </Robocopy>
   </Target>
 
@@ -51,9 +55,9 @@
       ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(RobocopyShowErrorOnRetry), 'true'))"
       DisableCopyOnWrite="$([MSBuild]::ValueOrDefault($(DisableCopyOnWrite), 'false'))"
       Sources="@(Robocopy)"
-      ListCopiedFiles="$('$(Robocopy_ListCopiedFiles)' == 'true')"
+      ListCopiedFiles="$(_RobocopyListCopiedFiles)"
       Condition="@(Robocopy->Count()) > 0">
-        <Output TaskParameter="CopiedFiles" ItemName="RobocopyFiles_CopiedFiles" />
+        <Output TaskParameter="CopiedFiles" ItemName="$(RobocopyCopiedFiles)" Condition="'$(_RobocopyListCopiedFiles)' != 'true'" />
       </Robocopy>
   </Target>
 </Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -34,7 +34,10 @@
       ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(ArtifactsShowErrorOnRetry), 'true'))"
       DisableCopyOnWrite="$([MSBuild]::ValueOrDefault($(DisableCopyOnWrite), 'false'))"
       Sources="@(Artifact)"
-      Condition="@(Artifact->Count()) > 0" />
+      ListCopiedFiles="$('$(Artifacts_ListCopiedFiles)' == 'true')"
+      Condition="@(Artifact->Count()) > 0">
+        <Output TaskParameter="CopiedFiles" ItemName="CopyArtifacts_CopiedFiles" />
+      </Robocopy>
   </Target>
 
   <Target Name="RobocopyFiles"
@@ -48,6 +51,9 @@
       ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(RobocopyShowErrorOnRetry), 'true'))"
       DisableCopyOnWrite="$([MSBuild]::ValueOrDefault($(DisableCopyOnWrite), 'false'))"
       Sources="@(Robocopy)"
-      Condition="@(Robocopy->Count()) > 0"/>
+      ListCopiedFiles="$('$(Robocopy_ListCopiedFiles)' == 'true')"
+      Condition="@(Robocopy->Count()) > 0">
+        <Output TaskParameter="CopiedFiles" ItemName="RobocopyFiles_CopiedFiles" />
+      </Robocopy>
   </Target>
 </Project>

--- a/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
+++ b/src/Artifacts/build/Microsoft.Build.Artifacts.Common.targets
@@ -7,10 +7,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildToolsVersion)' != 'Current'">$(MSBuildAllProjects);$(MsBuildThisFileFullPath)</MSBuildAllProjects>
-    <_ArtifactsListCopiedFiles Condition="'$(ArtifactsCopiedFiles)' != ''">true</_ArtifactsListCopiedFiles>
-    <_RobocopyListCopiedFiles Condition="'$(RobocopyCopiedFiles)' != ''">true</_RobocopyListCopiedFiles>
-    <ArtifactsCopiedFiles Condition="'$(ArtifactsCopiedFiles)' == ''">_</ArtifactsCopiedFiles>
-    <RobocopyCopiedFiles Condition="'$(RobocopyCopiedFiles)' == ''">_</RobocopyCopiedFiles>
   </PropertyGroup>
 
   <UsingTask TaskName="Robocopy"
@@ -31,6 +27,9 @@
           Condition="'$(EnableArtifacts)' != 'false'"
           AfterTargets="$([MSBuild]::ValueOrDefault($(CopyArtifactsAfterTargets), 'AfterBuild'))"
           DependsOnTargets="$(CopyArtifactsDependsOn)">
+    <PropertyGroup>
+      <_ArtifactsListCopiedFiles Condition="'$(ArtifactsCopiedFilesItemName)' != ''">true</_ArtifactsListCopiedFiles>
+    </PropertyGroup>
     <Robocopy
       RetryCount="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryCount), $(CopyRetryCount)))"
       RetryWait="$([MSBuild]::ValueOrDefault($(ArtifactsCopyRetryDelayMilliseconds), $(CopyRetryDelayMilliseconds)))"
@@ -40,7 +39,7 @@
       Sources="@(Artifact)"
       ListCopiedFiles="$(_ArtifactsListCopiedFiles)"
       Condition="@(Artifact->Count()) > 0">
-        <Output TaskParameter="CopiedFiles" ItemName="$(ArtifactsCopiedFiles)" Condition="'$(_ArtifactsListCopiedFiles)' != 'true'" />
+        <Output TaskParameter="CopiedFiles" ItemName="$(ArtifactsCopiedFilesItemName)" Condition="'$(ArtifactsCopiedFilesItemName)' != ''" />
       </Robocopy>
   </Target>
 
@@ -55,9 +54,9 @@
       ShowErrorOnRetry="$([MSBuild]::ValueOrDefault($(RobocopyShowErrorOnRetry), 'true'))"
       DisableCopyOnWrite="$([MSBuild]::ValueOrDefault($(DisableCopyOnWrite), 'false'))"
       Sources="@(Robocopy)"
-      ListCopiedFiles="$(_RobocopyListCopiedFiles)"
+      ListCopiedFiles="$(_ArtifactsListCopiedFiles)"
       Condition="@(Robocopy->Count()) > 0">
-        <Output TaskParameter="CopiedFiles" ItemName="$(RobocopyCopiedFiles)" Condition="'$(_RobocopyListCopiedFiles)' != 'true'" />
+      <Output TaskParameter="CopiedFiles" ItemName="$(ArtifactsCopiedFilesItemName)" Condition="'$(ArtifactsCopiedFilesItemName)' != ''" />
       </Robocopy>
   </Target>
 </Project>


### PR DESCRIPTION
Adds the ability for users to specify an item name to place the list of copied files into which is off-by-default

```xml
<PropertyGroup>
  <ArtifactsCopiedFilesItemName>SomethingCustom</ArtifactsCopiedFilesItemName>
</PropertyGroup>
```

The Artifacts targets will then place the list of copied files in that item group.