### PR TITLE
UniversalPackages: Fix setting User-Agent for dotnet scenarios

### DIFF
--- a/src/UniversalPackages/DownloadUniversalPackages.cs
+++ b/src/UniversalPackages/DownloadUniversalPackages.cs
@@ -629,7 +629,7 @@ public sealed class DownloadUniversalPackages : Task
         string json = webClient.DownloadString(ReleaseInfoUrl);
 #else
         using HttpClient httpClient = new HttpClient();
-        httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("Microsoft.Build.UniversalPackages"));
+        httpClient.DefaultRequestHeaders.TryAddWithoutValidation("User-Agent", "Microsoft.Build.UniversalPackages");
         string json = httpClient.GetStringAsync(ReleaseInfoUrl).GetAwaiter().GetResult();
 #endif
 


### PR DESCRIPTION
User-Agent has a special format apparently, but we don't really need to follow it. GitHub just requires some value.

This change makes it add the header directly without any validation.