### PR TITLE
UniversalPackages: Fix 'tar' command args

### DIFF
--- a/src/UniversalPackages/DownloadUniversalPackages.cs
+++ b/src/UniversalPackages/DownloadUniversalPackages.cs
@@ -659,7 +659,7 @@ public sealed class DownloadUniversalPackages : Task
                 : "linux-x64";
             fileExtension = ".tar.gz";
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             rid = RuntimeInformation.ProcessArchitecture == Architecture.Arm64
                 ? "osx-arm64"
@@ -751,7 +751,7 @@ public sealed class DownloadUniversalPackages : Task
                 // There is no built-in support for extracting tar.gz files, so fall back to the tar command.
                 int exitCode = ProcessHelper.Execute(
                     "/bin/bash",
-                    $"tar -xzf \"{archiveDownloadPath}\" -C \"{archiveExtractPath}\"",
+                    $"-c \"tar -xzf \\\"{archiveDownloadPath}\\\" -C \\\"{archiveExtractPath}\\\"\"",
                     processStdOut: message => Log.LogMessage(MessageImportance.Low, message),
                     processStdErr: message => Log.LogError(message));
                 if (exitCode != 0)


### PR DESCRIPTION
Fixes the error on Linux and OSX: `/usr/bin/tar: cannot execute binary file`.

This is because bash requires a `-c` param when being passed a command line to execute.