### PR TITLE
Universal Packages: Ensure tar destination dir exists

### DIFF
--- a/src/UniversalPackages/DownloadUniversalPackages.cs
+++ b/src/UniversalPackages/DownloadUniversalPackages.cs
@@ -759,6 +759,8 @@ public sealed class DownloadUniversalPackages : Task
             else
             {
                 // There is no built-in support for extracting tar.gz files, so fall back to the tar command.
+                // Note: the tar command requires that the destination directory already exist.
+                Directory.CreateDirectory(archiveExtractPath);
                 int exitCode = ProcessHelper.Execute(
                     "/bin/bash",
                     $"-c \"tar -xzf \\\"{archiveDownloadPath}\\\" -C \\\"{archiveExtractPath}\\\"\"",


### PR DESCRIPTION
The tar command requires that the destination dir already exist.