### PR TITLE
Universal Packages: Call chmod on executable when extracting from zip on Unix-based OS

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,11 @@
     <BaseArtifactsPath>$(MSBuildThisFileDirectory)artifacts\</BaseArtifactsPath>
     <EnableDefaultNoneItems>false</EnableDefaultNoneItems>
     <NoWarn>$(NoWarn);NU5128;SA0001</NoWarn>
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <!--
+      Disabling static graph restore due to a bug related to NuGetAuditSuppress.
+      See: https://github.com/NuGet/Home/issues/14300
+    -->
+    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
     <RestoreSerializeGlobalProperties>true</RestoreSerializeGlobalProperties>
     <UseArtifactsOutput>false</UseArtifactsOutput>
     <IsTestProject Condition="$(MSBuildProjectName.EndsWith('UnitTests'))">true</IsTestProject>

--- a/Directory.Solution.props
+++ b/Directory.Solution.props
@@ -1,6 +1,10 @@
 <Project>
   <PropertyGroup>
-    <RestoreUseStaticGraphEvaluation>true</RestoreUseStaticGraphEvaluation>
+    <!--
+      Disabling static graph restore due to a bug related to NuGetAuditSuppress.
+      See: https://github.com/NuGet/Home/issues/14300
+    -->
+    <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
     <RestoreSerializeGlobalProperties>true</RestoreSerializeGlobalProperties>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes errors like this on Linux and Mac:

```
System.ComponentModel.Win32Exception (13): An error occurred trying to start process '/home/vsts/work/1/s/~/.artifacttool/0.2.350/linux/x86_64/artifacttool' with working directory '/home/vsts/work/1/s'. Permission denied
```

This is because executables extracted from zip files do not retain the execute bit on Unix-based systems.