### PR TITLE
Suppress advisory for Microsoft.Build.Tasks.Core

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,12 @@
     <PackageVersion Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Build" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Framework" Version="$(MicrosoftBuildPackageVersion)" />
+    <!--
+      Suppress advisory for Microsoft.Build.Tasks.Core as this repo only compiles against these assemblies,
+      and uses a lower version for compatability. The actual version used at runtime is the version of
+      MSBuild actually running.
+    -->
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-h4j7-5rxr-p4wc" />
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="$(MicrosoftBuildPackageVersion)" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />


### PR DESCRIPTION
The pipeline is currently failing with:

```
D:\a\_work\1\s\src\CopyOnWrite\Microsoft.Build.CopyOnWrite.csproj : warning NU1901: Package 'Microsoft.Build.Tasks.Core' 16.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc [D:\a\_work\1\s\MSBuildSdks.sln]
D:\a\_work\1\s\src\Artifacts\Microsoft.Build.Artifacts.csproj : warning NU1901: Package 'Microsoft.Build.Tasks.Core' 16.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc [D:\a\_work\1\s\MSBuildSdks.sln]
D:\a\_work\1\s\src\RunTests\Microsoft.Build.RunVSTest.csproj : warning NU1901: Package 'Microsoft.Build.Tasks.Core' 17.11.4 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc [D:\a\_work\1\s\MSBuildSdks.sln]
D:\a\_work\1\s\src\Artifacts\Microsoft.Build.Artifacts.csproj : error NU1901: Package 'Microsoft.Build.Tasks.Core' 16.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc [TargetFramework=netstandard2.0]
D:\a\_work\1\s\src\CopyOnWrite\Microsoft.Build.CopyOnWrite.csproj : error NU1901: Package 'Microsoft.Build.Tasks.Core' 16.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc
D:\a\_work\1\s\src\RunTests\Microsoft.Build.RunVSTest.csproj : error NU1901: Package 'Microsoft.Build.Tasks.Core' 17.11.4 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc
D:\a\_work\1\s\src\CopyOnWrite\Microsoft.Build.CopyOnWrite.csproj : error NU1901: Package 'Microsoft.Build.Tasks.Core' 16.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc
D:\a\_work\1\s\src\CopyOnWrite\Microsoft.Build.CopyOnWrite.csproj : error NU1901: Package 'Microsoft.Build.Tasks.Core' 16.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc
D:\a\_work\1\s\src\Artifacts\Microsoft.Build.Artifacts.csproj : error NU1901: Package 'Microsoft.Build.Tasks.Core' 16.11.0 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc [TargetFramework=netstandard2.0]
D:\a\_work\1\s\src\RunTests\Microsoft.Build.RunVSTest.csproj : error NU1901: Package 'Microsoft.Build.Tasks.Core' 17.11.4 has a known low severity vulnerability, https://github.com/advisories/GHSA-h4j7-5rxr-p4wc
```