### PR TITLE
RunVSTest: Avoid parsing UT console output looking for errors or warnings

### DIFF
--- a/src/RunTests/RunVSTestTask.cs
+++ b/src/RunTests/RunVSTestTask.cs
@@ -153,7 +153,11 @@ namespace Microsoft.Build
         /// <inheritdoc/>
         protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
         {
-            base.LogEventsFromTextOutput(singleLine, messageImportance);
+            // Emit all log messages as regular log messages. The base class calls Log.LogMessageFromText which will
+            // parses the message see if there are strings which "look like" errors or warnings and log them as such.
+            // Since tests can log messages that look like errors or warnings, we want to avoid that and instead
+            // completely rely on the exit code of vstest to determine if the task succeeded or not.
+            Log.LogMessage(messageImportance, singleLine);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Today if a unit test logs a message which to MSBuild looks like an error, the task will unexpectedly fail.

This changes the logging call from `Log.LogMessageFromText` to simply `Log.LogMessage` to avoid this behavior.