### PR TITLE
Disable fast up to date check in Traversal

### DIFF
--- a/src/Traversal/Sdk/Traversal.props
+++ b/src/Traversal/Sdk/Traversal.props
@@ -22,6 +22,9 @@
 
     <!-- Targeting packs shouldn't be referenced as traversal projects don't compile. -->
     <DisableImplicitFrameworkReferences Condition="'$(DisableImplicitFrameworkReferences)' == ''">true</DisableImplicitFrameworkReferences>
+
+    <!-- Disable Visual Studio's Fast Up-to-date Check and rely on MSBuild to determine -->
+    <DisableFastUpToDateCheck Condition="'$(DisableFastUpToDateCheck)' == ''">true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(TraversalDoNotReferenceOutputAssemblies)' != 'false' ">


### PR DESCRIPTION
Same as in the NoTargets SDK:

https://github.com/microsoft/MSBuildSdks/blob/ccfc5583a21121a7b2ac50d412f5b77b46cce8d1/src/NoTargets/Sdk/Sdk.props#L56C1-L58C110