### PR TITLE
Add CreateManifestResourceNames target to Traversal

### DIFF
--- a/src/Traversal/Sdk/Traversal.props
+++ b/src/Traversal/Sdk/Traversal.props
@@ -37,6 +37,8 @@
     </ProjectReference>
   </ItemDefinitionGroup>
 
+  <Target Name="CreateManifestResourceNames" />
+
   <!-- For CPS/VS support. Importing in .props allows any subsequent targets to redefine this if needed -->
   <Target Name="CompileDesignTime" />
 </Project>


### PR DESCRIPTION
Same change as in NoTargets:

https://github.com/microsoft/MSBuildSdks/blob/ccfc5583a21121a7b2ac50d412f5b77b46cce8d1/src/NoTargets/Sdk/Sdk.props#L72C1-L72C48