### PR TITLE
Update property names to avoid conflicts 

### DIFF
--- a/src/Cargo/dist/msrustup.ps1
+++ b/src/Cargo/dist/msrustup.ps1
@@ -69,11 +69,12 @@ elseif ((Get-Command "azureauth" -ErrorAction SilentlyContinue) -ne $null) {
     azureauth ado token --output headervalue
 } else {
     $version = '0.9.1'
+    $env:AZUREAUTH_VERSION = $version
     $script = "${env:TEMP}\install.ps1"
     $url = "https://raw.githubusercontent.com/AzureAD/microsoft-authentication-cli/$version/install/install.ps1"
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
     Invoke-WebRequest $url -OutFile $script; if ($?) { &$script | Out-Null }; if ($?) { rm $script }
-    
+
     $path = "$env:LOCALAPPDATA\Programs\AzureAuth\$version\azureauth.exe"
     & $path ado token --output headervalue | Out-String
 }

--- a/src/Cargo/sdk/Sdk.props
+++ b/src/Cargo/sdk/Sdk.props
@@ -77,14 +77,15 @@
   <!-- Rust specific props -->
   <PropertyGroup>
     <AuthMode Condition="'$(AuthMode)' == ''">false</AuthMode>
-    <BuildCommandArgs Condition="'$(BuildCommandArgs)' == ''"></BuildCommandArgs>
-    <TestCommandArgs Condition="'$(TestCommandArgs)' == ''"></TestCommandArgs>
-    <CleanCommandArgs Condition="'$(CleanCommandArgs)' == ''"></CleanCommandArgs>
+    <CargoBuildCommandArgs Condition="'$(CargoBuildCommandArgs)' == ''"></CargoBuildCommandArgs>
+    <CargoTestCommandArgs Condition="'$(CargoTestCommandArgs)' == ''"></CargoTestCommandArgs>
+    <CargoCleanCommandArgs Condition="'$(CargoCleanCommandArgs)' == ''"></CargoCleanCommandArgs>
     <ClearCargoCacheCommandArgs Condition="'$(ClearCargoCacheCommandArgs)' == ''"></ClearCargoCacheCommandArgs>
     <CargoCommandArgs Condition="'$(CargoCommandArgs)' == ''"></CargoCommandArgs>
-    <RunCommandArgs Condition="'$(RunCommandArgs)' == ''"></RunCommandArgs>
+    <CargoRunCommandArgs Condition="'$(CargoRunCommandArgs)' == ''"></CargoRunCommandArgs>
     <CargoInstallCommandArgs Condition="'$(CargoInstallCommandArgs)' == ''"></CargoInstallCommandArgs>
-    <DocCommandArgs Condition="'$(DocCommandArgs)' == ''"></DocCommandArgs>
+    <CargoUpdateCommandArgs Condition="'$(CargoUpdateCommandArgs)' == ''"></CargoUpdateCommandArgs>
+    <CargoDocCommandArgs Condition="'$(CargoDocCommandArgs)' == ''"></CargoDocCommandArgs>
     <StartupProj Condition="'$(StartupProj)' == ''">$(MSBuildProjectFullPath)</StartupProj>
     <RepoRoot Condition="'$(RepoRoot)' == ''">$(EnlistmentRoot)</RepoRoot>
     <CargoInstallationRoot Condition="'$(CargoInstallationRoot)' == ''"></CargoInstallationRoot>

--- a/src/Cargo/sdk/Sdk.targets
+++ b/src/Cargo/sdk/Sdk.targets
@@ -119,19 +119,19 @@
     <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="fetch"  RepoRoot="$(RepoRoot)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoBuild" AfterTargets="CoreCompile">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build" CommandArgs="$(BuildCommandArgs)" Configuration="$(Configuration)" RepoRoot="$(RepoRoot)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build" CommandArgs="$(CargoBuildCommandArgs)" Configuration="$(Configuration)" RepoRoot="$(RepoRoot)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoTest" DependsOnTargets="CargoFetch">
-    <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(TestCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(CargoTestCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoRun" DependsOnTargets="CargoFetch">
-    <CargoTask StartupProj="$(StartupProj)" Command="run" CommandArgs="$(RunCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="run" CommandArgs="$(CargoRunCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoDoc" DependsOnTargets="CargoFetch">
-    <CargoTask StartupProj="$(StartupProj)" Command="doc" CommandArgs="$(DocCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="doc" CommandArgs="$(CargoDocCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoUpdate" DependsOnTargets="CargoFetch">
-    <CargoTask StartupProj="$(StartupProj)" Command="update" CommandArgs="$(UpdateCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="update" CommandArgs="$(CargoUpdateCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoInstall" DependsOnTargets="CargoFetch">
     <CargoTask StartupProj="$(StartupProj)" Command="install" CommandArgs="$(CargoInstallCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
@@ -140,7 +140,7 @@
     <CargoTask StartupProj="$(StartupProj)" Command="$(CargoCommand)" CommandArgs="$(CargoCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoClean">
-    <CargoTask StartupProj="$(StartupProj)" Command="clean" CommandArgs="$(CleanCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
+    <CargoTask StartupProj="$(StartupProj)" Command="clean" CommandArgs="$(CargoCleanCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="ClearCargoCache">
     <CargoTask StartupProj="$(StartupProj)" Command="clearcargocache" CommandArgs="$(ClearCargoCacheCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />


### PR DESCRIPTION
This change updates the names of the properties make them unique so as to avoid environment variable conflicts. It was discovered that the environment "BuildCommandArgs" is set under certain conditions when building in the cloud.
 