### PR TITLE
Exclude NoTargets projects from solution file

### DIFF
--- a/src/NoTargets/Sdk/Sdk.props
+++ b/src/NoTargets/Sdk/Sdk.props
@@ -56,6 +56,9 @@
     
     <!-- Disable Visual Studio's Fast Up-to-date Check and rely on MSBuild to determine -->
     <DisableFastUpToDateCheck Condition="'$(DisableFastUpToDateCheck)' == ''">true</DisableFastUpToDateCheck>
+
+    <!-- Exclude from SlnGen consideration since NoTargets projects do not need to be seen nor built in VS.  -->
+    <IncludeInSolutionFile>false</IncludeInSolutionFile>
   </PropertyGroup>
 
   <ItemDefinitionGroup Condition=" '$(NoTargetsDoNotReferenceOutputAssemblies)' != 'false' ">


### PR DESCRIPTION
Exclude NoTargets projects by default from SlnGen consideration since developers do not particularly need to see/build these projects in VS.