### PR TITLE
Import sdk targets

### DIFF
--- a/src/Cargo/sdk/InstallCargo.proj
+++ b/src/Cargo/sdk/InstallCargo.proj
@@ -1,5 +1,6 @@
 <Project>
   <Import Project="$(MSBuildThisFileDirectory)Sdk.props"/>
+  <Import Project="$(MSBuildThisFileDirectory)Sdk.targets"/>
   <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net8.0\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' == 'Core'" />
   <UsingTask TaskName="Microsoft.Build.Cargo.CargoTask" AssemblyFile="$(MSBuildThisFileDirectory)..\build\net472\Microsoft.Build.Cargo.dll" Condition="'$(MSBuildRuntimeType)' != 'Core'" />
   <Target Name="InstallCargo">


### PR DESCRIPTION
Import the Cargo SDK's `Sdk.targets` into `InstallCargo.proj` to fix #654 (Cargo SDK incompatible with the .NET 10 SDK).

## Bug
On the .NET 10 SDK, `dotnet restore` of any `.cargoproj` fails:

```
Microsoft.NET.PackProjectTool.props(16,13): error MSB4022:
The result "" of evaluating the value "$(MicrosoftNETBuildTasksAssembly)"
of the "AssemblyFile" attribute in element <UsingTask> is not valid.
```

Works on .NET 8/9; breaks only on .NET 10.

## Root cause
- The .NET 10 SDK added a new `<UsingTask ... AssemblyFile="$(MicrosoftNETBuildTasksAssembly)" />` to `Microsoft.NET.PackProjectTool.props` ([dotnet/sdk#49479](https://github.com/dotnet/sdk/pull/49479)). That file is imported from the SDK's **props**.
- `MicrosoftNETBuildTasksAssembly` is defined in `Microsoft.NET.Sdk.Common.targets` — i.e., in the SDK's **targets**.
- The standalone `InstallCargo.proj` (invoked as a separate MSBuild project during restore via the `InstallCargo` target) imported only `Sdk.props`, never `Sdk.targets`. So it inherited the new `UsingTask` but left `MicrosoftNETBuildTasksAssembly` empty → MSB4022. A normal `.cargoproj` imports both props and targets, so it is unaffected.

## Fix
Add `<Import Project="$(MSBuildThisFileDirectory)Sdk.targets"/>` to `InstallCargo.proj`. Cargo's `Sdk.targets` transitively imports the .NET SDK targets that define `MicrosoftNETBuildTasksAssembly`, so the SDK's `UsingTask` resolves to a real assembly.

Importing the targets at the bottom is sufficient because MSBuild fully evaluates properties (including those from later imports) before it evaluates `UsingTask` `AssemblyFile` attributes. There is no behavioral change: `InstallCargo.proj` is always invoked with an explicit `Targets="InstallCargo"`, so the additional targets are merely available, not executed.

Fixes #654.
