### PR TITLE
Add NuGet publish to official build pipeline

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -55,6 +55,13 @@ extends:
             condition: always()
             targetPath: '$(ArtifactsDirectoryName)'
             artifactName: $(ArtifactsDirectoryName)
+          - output: nuget
+            displayName: 'Push NuGet Packages to nuget.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/$(Build.SourceBranchName).nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
         steps:
         - task: PowerShell@2
           displayName: 'Update Build Number, and Add Build Tag for tagged commits'


### PR DESCRIPTION
Replace the classic release pipeline (blocked by 1ES drift management enforcement) with an `output: nuget` entry in the 1ES template's `templateContext.outputs` section.

**What this does:**
- Publishes to nuget.org via the 'MSBuild SDKs' service connection when a `Microsoft.Build*` tag is pushed
- Only publishes the package matching the tag (e.g., tag `Microsoft.Build.Artifacts.4.1.0` pushes only `Microsoft.Build.Artifacts.4.1.0.nupkg`)
- Uses `Build.SourceBranchName` to dynamically scope the glob, replacing the old per-package steps