### PR TITLE
Migrate official build pool to VSEng-MicroBuildVSStable

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -29,7 +29,7 @@ extends:
       sbom:
         enabled: false
     pool:
-      name: VSEngSS-MicroBuild2022-1ES
+      name: VSEng-MicroBuildVSStable
       demands:
       - msbuild
       - visualstudio
@@ -41,7 +41,7 @@ extends:
       - job: Build
         displayName: 'Build'
         pool:
-          name: 'VSEngSS-MicroBuild2022-1ES'
+          name: 'VSEng-MicroBuildVSStable'
         templateContext:
           mb:
             signing:


### PR DESCRIPTION
Update both pool references in `azure-pipelines-official.yml` from `VSEngSS-MicroBuild2022-1ES` to `VSEng-MicroBuildVSStable` (VS 2026 agents).

The .NET SDK version (10.x) is already correct and does not need updating.