### PR TITLE
Enable embedded PDBs and Source Link

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -18,4 +18,11 @@
     <!-- Suppress spam about using a preview version of .NET -->
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
+
+  <!-- Symbols and Source Link -->
+  <PropertyGroup>
+    <DebugType>embedded</DebugType>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+  </PropertyGroup>
 </Project>

--- a/src/Artifacts/Microsoft.Build.Artifacts.csproj
+++ b/src/Artifacts/Microsoft.Build.Artifacts.csproj
@@ -5,9 +5,6 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Build logic for staging artifacts from build outputs.</Description>
     <DevelopmentDependency>true</DevelopmentDependency>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\CopyExceptionHandling.cs" />

--- a/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
+++ b/src/CopyOnWrite/Microsoft.Build.CopyOnWrite.csproj
@@ -7,9 +7,6 @@
     <DevelopmentDependency>true</DevelopmentDependency>
     <LangVersion>latest</LangVersion>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>    
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Shared\CopyExceptionHandling.cs" />

--- a/src/RunTests/Microsoft.Build.RunVSTest.csproj
+++ b/src/RunTests/Microsoft.Build.RunVSTest.csproj
@@ -9,8 +9,6 @@
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
     <DevelopmentDependency>true</DevelopmentDependency>
     <LangVersion>latest</LangVersion>
-    <IncludeSymbols>true</IncludeSymbols>
-    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Tasks.Core" PrivateAssets="All" />


### PR DESCRIPTION
Add embedded PDB and Source Link configuration to `Directory.Build.props`:

- `DebugType=embedded` — embeds PDB data directly in the output assemblies
- `EmbedUntrackedSources=true` — includes source files not tracked by source control
- `PublishRepositoryUrl=true` — publishes the repository URL in the NuGet package

Source Link is built into the .NET 10 SDK, so no additional package references are needed. `RepositoryUrl` is already set in `Directory.Build.targets`.

Also removes the now-redundant per-project `IncludeSymbols`/`SymbolPackageFormat=snupkg` and `EmbedUntrackedSources` settings from Artifacts, CopyOnWrite, and RunVSTest projects, since these are handled centrally.