### PR TITLE
Migrate release publish to governed template

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,4 +31,4 @@ Create a new release at https://github.com/Microsoft/MSBuildSdks/releases.  The 
 Publishing the release will push a git tag which triggers [the governed official build](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?definitionId=13584) defined in [`azure-pipelines-official.yml`](azure-pipelines-official.yml). This build creates signed packages and uploads them as artifacts.
 
 ## NuGet.org publish
-The governed official build replaces the classic VSTS release. For tags in the `packageid.version` format, the pipeline publishes only the matching package to NuGet.org using the `MSBuild SDKs` service connection. The package should be available within 15 minutes after the pipeline completes.
+For tags in the `packageid.version` format, the governed official build publishes only the matching package to NuGet.org using the `MSBuild SDKs` service connection. The package should be available within 15 minutes after the pipeline completes.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -27,8 +27,8 @@ In this example, the version of `Microsoft.Build.CentralPackageVersions` is **1.
 
 Create a new release at https://github.com/Microsoft/MSBuildSdks/releases.  The tag should be in the format of `packageid.version`.  Using the above example, the tag would be `Microsoft.Build.CentralPackageVersions.1.0.34`.  Release notes should contain the important commits that are relevant to that release.  You can leave out commits that are not customer facing.
 
-## VSTS Build
-Publishing the release will push a git tag which triggers [an official build](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?definitionId=13584).  This build definition will also create signed packages and upload them as artifacts.
+## Official build
+Publishing the release will push a git tag which triggers [the governed official build](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_build?definitionId=13584) defined in [`azure-pipelines-official.yml`](azure-pipelines-official.yml). This build creates signed packages and uploads them as artifacts.
 
-## VSTS Release
-Once a build is complete, [a VSTS Release](https://devdiv.visualstudio.com/DefaultCollection/DevDiv/_release?definitionId=816&_a=releases) is automatically triggered which will queue up a task to push the package to nuget.org.  The publish task must be manually approved by a team member.  Watch for the email notification or manually find the waiting release to approve the task.  Following approval, the package should be available within 15 minutes.
+## NuGet.org publish
+The governed official build replaces the classic VSTS release. For tags in the `packageid.version` format, the pipeline publishes only the matching package to NuGet.org using the `MSBuild SDKs` service connection. The package should be available within 15 minutes after the pipeline completes.

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -56,12 +56,69 @@ extends:
             targetPath: '$(ArtifactsDirectoryName)'
             artifactName: $(ArtifactsDirectoryName)
           - output: nuget
-            displayName: 'Push NuGet Packages to nuget.org'
-            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build'))
+            displayName: 'Push Microsoft.Build.Artifacts to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.Artifacts'))
             packageParentPath: '$(ArtifactsDirectoryName)'
-            packagesToPush: '$(ArtifactsDirectoryName)/**/$(Build.SourceBranchName).nupkg'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.Artifacts.*.nupkg'
             nuGetFeedType: 'external'
             publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
+          - output: nuget
+            displayName: 'Push Microsoft.Build.CentralPackageVersions to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.CentralPackageVersions'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.CentralPackageVersions.*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
+          - output: nuget
+            displayName: 'Push Microsoft.Build.NoTargets to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.NoTargets'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.NoTargets.*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
+          - output: nuget
+            displayName: 'Push Microsoft.Build.Traversal to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.Traversal'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.Traversal.*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
+          - output: nuget
+            displayName: 'Push Microsoft.Build.CopyOnWrite to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.CopyOnWrite'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.CopyOnWrite.*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
+          - output: nuget
+            displayName: 'Push Microsoft.Build.RunVSTest to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.RunVSTest'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.RunVSTest.*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
+          - output: nuget
+            displayName: 'Push Microsoft.Build.Cargo to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.Cargo'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.Cargo.*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
+          - output: nuget
+            displayName: 'Push Microsoft.Build.UniversalPackages to NuGet.org'
+            condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/Microsoft.Build.UniversalPackages'))
+            packageParentPath: '$(ArtifactsDirectoryName)'
+            packagesToPush: '$(ArtifactsDirectoryName)/**/Microsoft.Build.UniversalPackages.*.nupkg'
+            nuGetFeedType: 'external'
+            publishFeedCredentials: 'MSBuild SDKs'
+            publishPackageMetadata: true
         steps:
         - task: PowerShell@2
           displayName: 'Update Build Number, and Add Build Tag for tagged commits'


### PR DESCRIPTION
## Summary
- Move NuGet.org publish rules into the governed official pipeline.
- Add package-specific NuGet publish outputs for tagged releases.
- Update release documentation to describe the governed publish flow.

## Validation
- Existing PR branch restored to its original commits after the accidental cross-branch update was moved to a separate PR.
