### PR TITLE
[s360-breeze-toolkit: SFI-ES4.2.4] Route NuGet restores through Azure Artifacts for CFS

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -10,6 +10,6 @@
   </activePackageSource>
   <packageSources>
     <clear />
-    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="VS-Platform" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/VS-Platform/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -25,6 +25,8 @@ pr: none
 extends:
   template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
   parameters:
+    settings:
+      networkIsolationPolicy: Permissive,CFSClean
     sdl:
       sbom:
         enabled: false
@@ -83,6 +85,8 @@ extends:
           inputs:
             version: '$(DotNetVersion)'
             includePreviewVersions: true
+        - task: NuGetAuthenticate@1
+          displayName: 'Authenticate NuGet feeds'
         - task: DotNetCoreCLI@2
           displayName: 'Build Solution'
           inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,9 @@ jobs:
       version: '$(DotNet10Version)'
       includePreviewVersions: true
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet feeds'
+
   - task: DotNetCoreCLI@2
     displayName: 'Build Solution'
     inputs:
@@ -127,6 +130,9 @@ jobs:
       version: '$(DotNet10Version)'
       includePreviewVersions: true
 
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet feeds'
+
   - task: DotNetCoreCLI@2
     displayName: 'dotnet build'
     inputs:
@@ -192,6 +198,9 @@ jobs:
     inputs:
       version: '$(DotNet10Version)'
       includePreviewVersions: true
+
+  - task: NuGetAuthenticate@1
+    displayName: 'Authenticate NuGet feeds'
 
   - task: DotNetCoreCLI@2
     displayName: 'dotnet build'

--- a/src/TestShared/MSBuildSdkTestBase.cs
+++ b/src/TestShared/MSBuildSdkTestBase.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Build.UnitTests.Common
 <configuration>
   <packageSources>
     <clear />
-    <add key=""NuGet.org"" value=""https://api.nuget.org/v3/index.json"" />
+    <add key=""VS-Platform"" value=""https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/VS-Platform/nuget/v3/index.json"" />
   </packageSources>
 </configuration>");
         }


### PR DESCRIPTION
## Summary
- Replace public NuGet restore sources with the internal VS-Platform Azure Artifacts feed in the repo NuGet configuration and test-generated NuGet config.
- Add NuGet feed authentication before restore/build work in the Azure Pipelines definitions.
- Enable `Permissive,CFSClean` on the governed official pipeline so public NuGet endpoint traffic is blocked by network isolation.

## Validation
- `dotnet nuget list source --configfile NuGet.config`
- `git diff --check`
- Confirmed all centrally declared package versions exist in the VS-Platform feed.
- Ran one restore sanity check with temporary Azure DevOps feed credentials; restore completed successfully.

## ES 4.2.4 follow-up
After the next pipeline run, expand the **Stop Network Isolation** task and check **Audited Connections**. If the run is clean, trigger two more runs within 7 days; after 3 clean runs over 7 days, the S360 item should auto-resolve.

---
🛠️ s360-breeze-toolkit · SFI-ES4.2.4 · run `39d6d5d7`
<!-- s360-toolkit-attribution: {"schema":"1.0","run_id":"39d6d5d7-89eb-4b1f-94e4-35a06d26eb85","kpi_id":"SFI-ES4.2.4","program":"SFI","skill":"sfi-es424-central-feed-services","arm":"dedicated_skill","action_items":[],"plugin_version":"2.1.0","plugin_channel":"local"} -->
