### PR TITLE
Remove .NET SDK pin from global.json

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,20 @@
 
 # Contributing
 
+## Prerequisites
+
+This repository does not pin a specific .NET SDK version in `global.json`; the
+build uses whichever SDK is installed. To build and test locally you need:
+
+- A current .NET 10 SDK (the build targets the latest 10.x).
+- .NET 8 and .NET 9 SDKs as well, since the test projects target `net8.0`,
+  `net9.0`, and `net10.0` (plus `net472` on Windows).
+
+CI installs these via `UseDotNet@2` (`8.x`, `9.x`, `10.x`); mirror that
+locally. Download them from <https://dotnet.microsoft.com/download>.
+
+## Contributions
+
 This project welcomes contributions and suggestions.  Most contributions require you to agree to a
 Contributor License Agreement (CLA) declaring that you have the right to, and actually do, grant us
 the rights to use your contribution. For details, visit https://cla.microsoft.com.

--- a/global.json
+++ b/global.json
@@ -1,9 +1,4 @@
 {
-  "sdk": {
-    "version": "10.0.203",
-    "rollForward": "latestMinor",
-    "allowPrerelease": true
-  },
   "msbuild-sdks": {
     "Microsoft.Build.NoTargets": "3.7.134"
   }


### PR DESCRIPTION
SFI scanners flag the literal SDK version in `global.json` even though `rollForward: latestMinor` already lets the build use newer 10.x SDKs. The pipelines (`azure-pipelines.yml` and `azure-pipelines-official.yml`) already install `10.x` via `UseDotNet@2`, so dropping the `sdk` block lets CI keep tracking the latest 10.x automatically and leaves no version string for scanners to flag.

Also adds a Prerequisites section to `CONTRIBUTING.md` so local devs know they need .NET 8/9/10 SDKs installed (mirroring CI).

Verified with a full local `dotnet build` (0 warnings/0 errors) using auto-selected SDK 10.0.300.