### PR TITLE
Fix official CFS nested SDK restore

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -9,7 +9,7 @@ variables:
   BuildConfiguration: 'Release'
   BuildPlatform: 'Any CPU'
   DotNetVersion: '10.x'
-  MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.CFS.config" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
+  MSBuildArgs: '"/p:Platform=$(BuildPlatform)" "/p:Configuration=$(BuildConfiguration)" "/p:RestoreConfigFile=$(Build.SourcesDirectory)\NuGet.config" "/BinaryLogger:$(Build.SourcesDirectory)\$(ArtifactsDirectoryName)\msbuild.binlog"'
   SignType: 'Real'
 trigger:
   batch: 'true'
@@ -87,6 +87,9 @@ extends:
             includePreviewVersions: true
         - task: NuGetAuthenticate@1
           displayName: 'Authenticate Azure Artifacts feeds'
+        - powershell: |
+            Copy-Item -LiteralPath '$(Build.SourcesDirectory)\NuGet.CFS.config' -Destination '$(Build.SourcesDirectory)\NuGet.config' -Force
+          displayName: 'Use CFS NuGet config'
         - task: DotNetCoreCLI@2
           displayName: 'Build Solution'
           inputs:


### PR DESCRIPTION
## Summary
- Fix the official CFS pipeline follow-up from #670.
- Copy `NuGet.CFS.config` over `NuGet.config` after `NuGetAuthenticate@1` and before build.
- Keep `RestoreConfigFile` pointed at root `NuGet.config` so nested MSBuild/MicroBuild/Guardian evaluations resolve SDK packages such as `Microsoft.Build.NoTargets` from the CFS feed.

## Why
The official build failed in [DevDiv build 14261839](https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=14261839&view=logs&j=d2bf1b80-3df3-55be-12c2-3a635e515050&t=06e225b7-302a-5198-02a9-4687c66dcbed) with `MSB4236` while resolving the MSBuild SDK package:

```text
Error : Could not resolve SDK "Microsoft.Build.NoTargets". Exactly one of the probing messages below indicates why we could not resolve the SDK.
  SDK resolver "Microsoft.DotNet.MSBuildWorkloadSdkResolver" returned null.
  Unable to find package Microsoft.Build.NoTargets. No packages exist with this id in source(s): NuGet.org
Error MSB4236: The SDK 'Microsoft.Build.NoTargets/3.7.134' specified could not be found.
```

The build command already passed `/p:RestoreConfigFile=D:\a\_work\1\s\NuGet.CFS.config`, and normal package restore mostly succeeded. However, the SDK resolver still read the root `NuGet.config`, attempted `https://api.nuget.org/v3/index.json`, and Network Isolation reported a blocked `api.nuget.org` connection from `dotnet.exe`.

This change swaps the CFS config into the root `NuGet.config` path for the official pipeline workspace so SDK resolution and nested MSBuild evaluations use the same CFS feed configuration as package restore.

## Validation
- Locally emulated the official pipeline flow by copying `NuGet.CFS.config` over `NuGet.config`, then running:
  `dotnet build .\MSBuildSdks.sln -p:Configuration=Release '-p:Platform=Any CPU' -p:RestoreConfigFile=D:\MSBuildSdks\cfs\NuGet.config`
- Reviewed the authenticated official build logs from build 14261839 to confirm the failure source was `NuGet.org` during SDK resolution, not VS-Platform authentication.
