### PR TITLE
Fix net472 ProjectCacheService.DisposeAsync pipeline failure

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -19,6 +19,13 @@
     <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(IsTestProject)' == 'true' And '$(TargetFramework)' == 'net472'">
+    <!-- MSBuild.ProjectCreation loads MSBuild's runtime closure from Visual Studio. -->
+    <PackageReference Include="System.Threading.Tasks.Extensions"
+                      ExcludeAssets="runtime"
+                      PrivateAssets="all" />
+  </ItemGroup>
+
   <!-- Symbols and Source Link -->
   <PropertyGroup>
     <DebugType>embedded</DebugType>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,6 +70,7 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="MSBuild.ProjectCreation" Version="17.0.1" />
     <PackageVersion Include="Shouldly" Version="4.2.1" />
+    <PackageVersion Include="System.Threading.Tasks.Extensions" Version="4.6.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.analyzers" Version="1.25.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />


### PR DESCRIPTION
## Summary

- Fix the net472 test failure where `ProjectCacheService` did not satisfy the loaded `IAsyncDisposable.DisposeAsync` contract.
- Prevent the test output from mixing its transitive `System.Threading.Tasks.Extensions` runtime assembly with the MSBuild runtime closure loaded from Visual Studio by `MSBuild.ProjectCreation`.
- Keep `System.Threading.Tasks.Extensions` available for compilation while excluding its runtime asset only for net472 test projects.

## Testing

- Full solution build
- All six net472 test assemblies: 287/287 passed
- Focused `SolutionsCanSkipProjects` reproduction
