### PR TITLE
Publish Cargo outputs through MSBuild

### DIFF
--- a/src/Cargo.UnitTests/CargoTest.cs
+++ b/src/Cargo.UnitTests/CargoTest.cs
@@ -378,13 +378,16 @@ namespace Microsoft.Build.Cargo.UnitTests
         }
 
         [Theory]
-        [InlineData(null, null)]
-        [InlineData("cargo-target", null)]
-        [InlineData(null, @"artifacts\obj\Cargo\")]
-        public void PublishesOnlyDeclaredCargoBuildOutputs(string cargoOutputDirectoryName, string baseIntermediateOutputPath)
+        [InlineData(null, false)]
+        [InlineData("cargo-target", false)]
+        [InlineData(null, true)]
+        public void PublishesOnlyDeclaredCargoBuildOutputs(string cargoOutputDirectoryName, bool useCustomBaseIntermediateOutputPath)
         {
             string projectDirectory = Path.Combine(TestRootPath, "Cargo");
             string projectPath = Path.Combine(projectDirectory, "rust.cargoproj");
+            string baseIntermediateOutputPath = useCustomBaseIntermediateOutputPath
+                ? Path.Combine("artifacts", "obj", "Cargo") + Path.DirectorySeparatorChar
+                : null;
             string cargoOutputDirectory = cargoOutputDirectoryName == null
                 ? Path.Combine(projectDirectory, baseIntermediateOutputPath ?? "obj", "cargo")
                 : Path.Combine(projectDirectory, cargoOutputDirectoryName);
@@ -393,6 +396,7 @@ namespace Microsoft.Build.Cargo.UnitTests
             string intermediatePath = Path.Combine(sourceDirectory, "deps", "dependency.rlib");
             string outputDirectory = Path.Combine(projectDirectory, "artifacts", "bin", "Release", CargoTargetFramework);
             string publishedPath = Path.Combine(outputDirectory, "native", "rust_lib_external.lib");
+            string targetPath = Path.Combine("native", "rust_lib_external.lib");
 
             Directory.CreateDirectory(Path.GetDirectoryName(intermediatePath));
             File.WriteAllText(sourcePath, "primary output");
@@ -410,10 +414,10 @@ namespace Microsoft.Build.Cargo.UnitTests
                 .Property("OutputPath", @"artifacts\bin\$(Configuration)")
                 .ItemInclude(
                     "CargoBuildOutput",
-                    @"$(CargoOutputDir)\$(Configuration)\rust_lib_external.dll.lib",
+                    Path.Combine("$(CargoOutputDir)", "$(Configuration)", "rust_lib_external.dll.lib"),
                     metadata: new Dictionary<string, string>
                     {
-                        ["TargetPath"] = @"native\rust_lib_external.lib",
+                        ["TargetPath"] = targetPath,
                     })
                 .Target("InstallCargo")
                 .Target("CargoFetch")
@@ -436,7 +440,7 @@ namespace Microsoft.Build.Cargo.UnitTests
             File.ReadAllText(publishedPath).ShouldBe("primary output");
             File.Exists(Path.Combine(outputDirectory, "deps", "dependency.rlib")).ShouldBeFalse();
             buildOutput.Messages.High.ShouldContain(
-                $"CargoPublishedOutput={publishedPath}|{sourcePath}|native\\rust_lib_external.lib",
+                $"CargoPublishedOutput={publishedPath}|{sourcePath}|{targetPath}",
                 buildOutput.GetConsoleLog());
         }
 

--- a/src/Cargo.UnitTests/CargoTest.cs
+++ b/src/Cargo.UnitTests/CargoTest.cs
@@ -11,15 +11,22 @@ using Microsoft.Build.Utilities.ProjectCreation;
 using Shouldly;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.Json;
 using Xunit;
 
 namespace Microsoft.Build.Cargo.UnitTests
 {
     public class CargoTest : MSBuildSdkTestBase
     {
+#if NETFRAMEWORK
+        private const string CargoTargetFramework = "net472";
+#else
+        private const string CargoTargetFramework = "netstandard2.0";
+#endif
         private static readonly string ThisAssemblyDirectory = Path.GetDirectoryName(typeof(CustomProjectCreatorTemplates).Assembly.Location);
 
         [Fact]
@@ -185,6 +192,432 @@ namespace Microsoft.Build.Cargo.UnitTests
             project2.TryBuild(out bool result, out BuildOutput buildOutput);
 
             result.ShouldBeTrue(buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void DiscoversPrimaryCargoBuildOutputsFromJsonMessages()
+        {
+            string projectDirectory = Path.Combine(TestRootPath, "Cargo");
+            string manifestPath = Path.Combine(projectDirectory, "Cargo.toml");
+            string dependencyManifestPath = Path.Combine(TestRootPath, "Dependency", "Cargo.toml");
+            string dynamicLibraryPath = Path.Combine(projectDirectory, "target", "release", "example.dll");
+            string importLibraryPath = dynamicLibraryPath + ".lib";
+            string symbolsPath = Path.ChangeExtension(dynamicLibraryPath, ".pdb");
+            string rustLibraryPath = Path.Combine(projectDirectory, "target", "release", "example.rlib");
+            string executablePath = Path.Combine(projectDirectory, "target", "release", "example");
+            string dependencyPath = Path.Combine(TestRootPath, "Dependency", "target", "release", "dependency.dll");
+            string buildScriptPath = Path.Combine(projectDirectory, "target", "release", "build-script-build.exe");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(dynamicLibraryPath));
+            Directory.CreateDirectory(Path.GetDirectoryName(dependencyPath));
+            foreach (string path in new[] { dynamicLibraryPath, importLibraryPath, symbolsPath, rustLibraryPath, executablePath, dependencyPath, buildScriptPath })
+            {
+                File.WriteAllText(path, path);
+            }
+
+            string[] messages =
+            {
+                "Compiling example",
+                JsonSerializer.Serialize(new
+                {
+                    reason = "compiler-artifact",
+                    manifest_path = dependencyManifestPath,
+                    target = new { kind = new[] { "cdylib" }, crate_types = new[] { "cdylib" } },
+                    filenames = new[] { dependencyPath },
+                    executable = (string)null,
+                }),
+                JsonSerializer.Serialize(new
+                {
+                    reason = "compiler-artifact",
+                    manifest_path = manifestPath,
+                    target = new { kind = new[] { "custom-build" }, crate_types = new[] { "bin" } },
+                    filenames = new[] { buildScriptPath },
+                    executable = buildScriptPath,
+                }),
+                JsonSerializer.Serialize(new
+                {
+                    reason = "compiler-artifact",
+                    manifest_path = manifestPath,
+                    target = new { kind = new[] { "cdylib" }, crate_types = new[] { "cdylib" } },
+                    filenames = new[] { dynamicLibraryPath, rustLibraryPath },
+                    executable = executablePath,
+                }),
+            };
+
+            IReadOnlyList<string> outputs = CargoArtifactDiscovery.DiscoverPrimaryBuildOutputs(messages, manifestPath);
+
+            outputs.ShouldBe(
+                new[] { dynamicLibraryPath, executablePath, importLibraryPath, symbolsPath },
+                ignoreOrder: true);
+        }
+
+        [Theory]
+        [InlineData("", true, "--message-format=json-render-diagnostics")]
+        [InlineData("--release", true, "--release --message-format=json-render-diagnostics")]
+        [InlineData("--message-format=json", true, "--message-format=json")]
+        [InlineData("--message-format json-render-diagnostics", true, "--message-format json-render-diagnostics")]
+        [InlineData("--message-format=short", false, "--message-format=short")]
+        public void RequiresJsonMessageFormatForCargoBuild(string arguments, bool expectedResult, string expectedArguments)
+        {
+            bool result = CargoBuildArguments.TryEnsureJsonMessageFormat(arguments, out string effectiveArguments);
+
+            result.ShouldBe(expectedResult);
+            effectiveArguments.ShouldBe(expectedArguments);
+        }
+
+        [Fact]
+        public void TerminatesCargoProcessTree()
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                return;
+            }
+
+            using var parent = Process.Start(new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                Arguments = "-NoProfile -Command \"$child = Start-Process powershell.exe -ArgumentList '-NoProfile','-Command','Start-Sleep -Seconds 60' -PassThru; Write-Output $child.Id; [Console]::Out.Flush(); Start-Sleep -Seconds 60\"",
+                CreateNoWindow = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            });
+
+            parent.ShouldNotBeNull();
+            string childProcessId = parent.StandardOutput.ReadLine();
+            int.TryParse(childProcessId, out int childId).ShouldBeTrue();
+
+            using Process child = Process.GetProcessById(childId);
+
+            ProcessTreeTermination.Terminate(parent, _ => { });
+
+            parent.WaitForExit(10_000).ShouldBeTrue();
+            child.WaitForExit(10_000).ShouldBeTrue();
+        }
+
+        [Fact]
+        public void LoadsDiscoveredCargoBuildOutputsForProjectReferenceQueries()
+        {
+            string projectDirectory = Path.Combine(TestRootPath, "Cargo");
+            string cachePath = Path.Combine(projectDirectory, "obj", "Debug", CargoTargetFramework, "Microsoft.Build.Cargo.outputs");
+            string publishedPath = Path.Combine(projectDirectory, "artifacts", "bin", CargoTargetFramework, "automatic.lib");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(cachePath));
+            Directory.CreateDirectory(Path.GetDirectoryName(publishedPath));
+            File.WriteAllText(publishedPath, "automatic output");
+            File.WriteAllText(cachePath, publishedPath);
+
+            ProjectCreator.Templates.CargoProject(
+                    path: Path.Combine(projectDirectory, "rust.cargoproj"))
+                .Property("OutputPath", @"artifacts\bin\")
+                .Target("ReportCargoTargetPaths", afterTargets: "GetTargetPath")
+                    .TaskMessage("CargoTargetPath=%(TargetPathWithTargetPlatformMoniker.FullPath)", MessageImportance.High)
+                .Save()
+                .TryBuild("GetTargetPath", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            buildOutput.Messages.High.ShouldContain($"CargoTargetPath={publishedPath}", buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void PublishesAutomaticallyDiscoveredCargoBuildOutput()
+        {
+            string projectDirectory = Path.Combine(TestRootPath, "Cargo");
+            string sourcePath = Path.Combine(projectDirectory, "obj", "cargo", "release", "automatic.lib");
+            string publishedPath = Path.Combine(projectDirectory, "artifacts", "bin", CargoTargetFramework, "automatic.lib");
+            string cachePath = Path.Combine(projectDirectory, "obj", "Debug", CargoTargetFramework, "Microsoft.Build.Cargo.outputs");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath));
+            File.WriteAllText(sourcePath, "automatic output");
+
+            ProjectCreator.Templates.CargoProject(
+                    path: Path.Combine(projectDirectory, "rust.cargoproj"))
+                .Property("OutputPath", @"artifacts\bin\")
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                    .TargetItemInclude("_DiscoveredCargoBuildOutput", sourcePath)
+                .Save()
+                .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            File.ReadAllText(publishedPath).ShouldBe("automatic output");
+            File.ReadAllLines(cachePath).ShouldBe(new[] { publishedPath });
+        }
+
+        [Fact]
+        public void ExplicitCargoBuildOutputOverridesAutomaticPublicationMetadata()
+        {
+            string projectDirectory = Path.Combine(TestRootPath, "Cargo");
+            string sourcePath = Path.Combine(projectDirectory, "obj", "cargo", "release", "automatic.lib");
+            string defaultPublishedPath = Path.Combine(projectDirectory, "artifacts", "bin", CargoTargetFramework, "automatic.lib");
+            string overriddenPublishedPath = Path.Combine(projectDirectory, "artifacts", "bin", CargoTargetFramework, "native", "renamed.lib");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath));
+            File.WriteAllText(sourcePath, "automatic output");
+
+            ProjectCreator.Templates.CargoProject(
+                    path: Path.Combine(projectDirectory, "rust.cargoproj"))
+                .Property("OutputPath", @"artifacts\bin\")
+                .ItemInclude(
+                    "CargoBuildOutput",
+                    sourcePath,
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["TargetPath"] = @"native\renamed.lib",
+                    })
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                    .TargetItemInclude("_DiscoveredCargoBuildOutput", sourcePath)
+                .Save()
+                .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            File.Exists(defaultPublishedPath).ShouldBeFalse();
+            File.ReadAllText(overriddenPublishedPath).ShouldBe("automatic output");
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("cargo-target", null)]
+        [InlineData(null, @"artifacts\obj\Cargo\")]
+        public void PublishesOnlyDeclaredCargoBuildOutputs(string cargoOutputDirectoryName, string baseIntermediateOutputPath)
+        {
+            string projectDirectory = Path.Combine(TestRootPath, "Cargo");
+            string projectPath = Path.Combine(projectDirectory, "rust.cargoproj");
+            string cargoOutputDirectory = cargoOutputDirectoryName == null
+                ? Path.Combine(projectDirectory, baseIntermediateOutputPath ?? "obj", "cargo")
+                : Path.Combine(projectDirectory, cargoOutputDirectoryName);
+            string sourceDirectory = Path.Combine(cargoOutputDirectory, "Release");
+            string sourcePath = Path.Combine(sourceDirectory, "rust_lib_external.dll.lib");
+            string intermediatePath = Path.Combine(sourceDirectory, "deps", "dependency.rlib");
+            string outputDirectory = Path.Combine(projectDirectory, "artifacts", "bin", "Release", CargoTargetFramework);
+            string publishedPath = Path.Combine(outputDirectory, "native", "rust_lib_external.lib");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(intermediatePath));
+            File.WriteAllText(sourcePath, "primary output");
+            File.WriteAllText(intermediatePath, "cargo intermediate");
+
+            ProjectCreator cargoProject = ProjectCreator.Templates.CargoProject(
+                    path: projectPath,
+                    globalProperties: baseIntermediateOutputPath == null
+                        ? null
+                        : new Dictionary<string, string>
+                        {
+                            ["BaseIntermediateOutputPath"] = baseIntermediateOutputPath,
+                        })
+                .Property("Configuration", "Release")
+                .Property("OutputPath", @"artifacts\bin\$(Configuration)")
+                .ItemInclude(
+                    "CargoBuildOutput",
+                    @"$(CargoOutputDir)\$(Configuration)\rust_lib_external.dll.lib",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["TargetPath"] = @"native\rust_lib_external.lib",
+                    })
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                .Target("ReportCargoPublishedOutput", afterTargets: "PublishCargoBuildOutputs")
+                    .TaskMessage(
+                        "CargoPublishedOutput=%(CargoPublishedOutput.FullPath)|%(CargoPublishedOutput.SourcePath)|%(CargoPublishedOutput.TargetPath)",
+                        MessageImportance.High);
+
+            if (cargoOutputDirectoryName != null)
+            {
+                cargoProject.Property("CargoOutputDir", cargoOutputDirectory);
+            }
+
+            cargoProject
+                .Save()
+                .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            File.ReadAllText(publishedPath).ShouldBe("primary output");
+            File.Exists(Path.Combine(outputDirectory, "deps", "dependency.rlib")).ShouldBeFalse();
+            buildOutput.Messages.High.ShouldContain(
+                $"CargoPublishedOutput={publishedPath}|{sourcePath}|native\\rust_lib_external.lib",
+                buildOutput.GetConsoleLog());
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(false, false)]
+        public void HandlesAbsentCargoBuildOutputs(bool optional, bool expectedResult)
+        {
+            ProjectCreator.Templates.CargoProject(
+                    path: Path.Combine(TestRootPath, "Cargo", "rust.cargoproj"))
+                .Property("OutputPath", @"artifacts\bin\")
+                .ItemInclude(
+                    "CargoBuildOutput",
+                    @"$(CargoOutputDir)\missing.lib",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Optional"] = optional.ToString(),
+                    })
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                .Save()
+                .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBe(expectedResult, buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void RemovesCargoBuildOutputWhenItBecomesOptionalAndAbsent()
+        {
+            string projectDirectory = Path.Combine(TestRootPath, "Cargo");
+            string sourcePath = Path.Combine(projectDirectory, "obj", "cargo", "optional.lib");
+            string publishedPath = Path.Combine(projectDirectory, "artifacts", "bin", CargoTargetFramework, "optional.lib");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath));
+            File.WriteAllText(sourcePath, "optional output");
+
+            ProjectCreator cargoProject = ProjectCreator.Templates.CargoProject(
+                    path: Path.Combine(projectDirectory, "rust.cargoproj"))
+                .Property("OutputPath", @"artifacts\bin\")
+                .ItemInclude(
+                    "CargoBuildOutput",
+                    @"$(CargoOutputDir)\optional.lib",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["Optional"] = bool.TrueString,
+                    })
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                .Target("ReportCargoTargetPaths", afterTargets: "GetTargetPath")
+                    .TaskMessage("CargoTargetPath=%(TargetPathWithTargetPlatformMoniker.FullPath)", MessageImportance.High)
+                .Save();
+
+            cargoProject.TryBuild(restore: true, "Build", out bool initialResult, out BuildOutput initialBuildOutput);
+
+            initialResult.ShouldBeTrue(initialBuildOutput.GetConsoleLog());
+            File.Exists(publishedPath).ShouldBeTrue();
+
+            File.Delete(sourcePath);
+
+            cargoProject.TryBuild("Build", out bool rebuildResult, out BuildOutput rebuildOutput);
+
+            rebuildResult.ShouldBeTrue(rebuildOutput.GetConsoleLog());
+            File.Exists(publishedPath).ShouldBeFalse();
+            rebuildOutput.Messages.High.ShouldNotContain($"CargoTargetPath={publishedPath}");
+        }
+
+        [Theory]
+        [InlineData(@"..\escaped.lib")]
+        [InlineData(@"\escaped.lib")]
+        public void RejectsCargoBuildOutputOutsideOutputPath(string targetPath)
+        {
+            string projectDirectory = Path.Combine(TestRootPath, "Cargo");
+            string sourcePath = Path.Combine(projectDirectory, "obj", "cargo", "output.lib");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath));
+            File.WriteAllText(sourcePath, "output");
+
+            ProjectCreator.Templates.CargoProject(
+                    path: Path.Combine(projectDirectory, "rust.cargoproj"))
+                .Property("OutputPath", @"artifacts\bin\")
+                .ItemInclude(
+                    "CargoBuildOutput",
+                    @"$(CargoOutputDir)\output.lib",
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["TargetPath"] = targetPath,
+                    })
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                .Save()
+                .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeFalse(buildOutput.GetConsoleLog());
+            buildOutput.Errors.ShouldContain(
+                error => error.Contains("must remain under", StringComparison.OrdinalIgnoreCase),
+                buildOutput.GetConsoleLog());
+        }
+
+        [Fact]
+        public void DependentProjectSeesPublishedCargoBuildOutput()
+        {
+            string producerDirectory = Path.Combine(TestRootPath, "Producer");
+            string producerPath = Path.Combine(producerDirectory, "producer.cargoproj");
+            string sourcePath = Path.Combine(producerDirectory, "obj", "cargo", "release", "rust_lib_external.dll.lib");
+            string publishedPath = Path.Combine(producerDirectory, "artifacts", "bin", "Release", CargoTargetFramework, "rust_lib_external.dll.lib");
+            string consumerOutputPath = Path.Combine(TestRootPath, "Consumer", "artifacts", "bin", "Release", CargoTargetFramework, "rust_lib_external.dll.lib");
+
+            Directory.CreateDirectory(Path.GetDirectoryName(sourcePath));
+            File.WriteAllText(sourcePath, "native import library");
+
+            ProjectCreator producer = ProjectCreator.Templates.CargoProject(path: producerPath)
+                .Property("Configuration", "Release")
+                .Property("OutputPath", @"artifacts\bin\$(Configuration)")
+                .ItemInclude("CargoBuildOutput", @"$(CargoOutputDir)\release\rust_lib_external.dll.lib")
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                .Target("ReportCargoTargetPaths", afterTargets: "GetTargetPath")
+                    .TaskMessage(
+                        "CargoTargetPath=%(TargetPathWithTargetPlatformMoniker.FullPath)|%(TargetPathWithTargetPlatformMoniker.FileType)",
+                        MessageImportance.High)
+                .Target("ReportCargoCopyItems", afterTargets: "GetCopyToOutputDirectoryItems")
+                    .TaskMessage("CargoCopyItem=%(AllItemsFullPathWithTargetPath.FullPath)", MessageImportance.High)
+                .Save();
+
+            producer.TryBuild(restore: true, "Build", out bool producerResult, out BuildOutput producerBuildOutput);
+
+            producerResult.ShouldBeTrue(producerBuildOutput.GetConsoleLog());
+            File.Delete(sourcePath);
+
+            producer.TryBuild("GetTargetPath", out bool targetPathResult, out BuildOutput targetPathBuildOutput);
+            producer.TryBuild("GetCopyToOutputDirectoryItems", out bool copyItemsResult, out BuildOutput copyItemsBuildOutput);
+
+            targetPathResult.ShouldBeTrue(targetPathBuildOutput.GetConsoleLog());
+            targetPathBuildOutput.Messages.High.ShouldContain($"CargoTargetPath={publishedPath}|lib", targetPathBuildOutput.GetConsoleLog());
+            targetPathBuildOutput.GetConsoleLog().ShouldNotContain(sourcePath);
+            copyItemsResult.ShouldBeTrue(copyItemsBuildOutput.GetConsoleLog());
+            copyItemsBuildOutput.Messages.High.ShouldContain($"CargoCopyItem={publishedPath}", copyItemsBuildOutput.GetConsoleLog());
+            copyItemsBuildOutput.GetConsoleLog().ShouldNotContain(sourcePath);
+            File.WriteAllText(sourcePath, "native import library");
+
+            ProjectCreator.Templates.CargoProject(
+                    path: Path.Combine(TestRootPath, "Consumer", "consumer.cargoproj"))
+                .Property("Configuration", "Release")
+                .Property("OutputPath", @"artifacts\bin\$(Configuration)")
+                .ItemInclude(
+                    "ProjectReference",
+                    producerPath,
+                    metadata: new Dictionary<string, string>
+                    {
+                        ["OutputItemType"] = "NativeInput",
+                        ["ReferenceOutputAssembly"] = bool.FalseString,
+                        ["SkipGetTargetFrameworkProperties"] = bool.TrueString,
+                    })
+                .Target("InstallCargo")
+                .Target("CargoFetch")
+                .Target("CargoBuild", afterTargets: "CoreCompile")
+                .Target("VerifyCargoOutput", beforeTargets: "CoreCompile")
+                    .Task(
+                        "Error",
+                        condition: $"!Exists('{publishedPath}')",
+                        parameters: new Dictionary<string, string>
+                        {
+                            ["Text"] = $"Cargo output was not published to '{publishedPath}'.",
+                        })
+                    .Task(
+                        "Error",
+                        condition: $"'%(NativeInput.FullPath)' != '{publishedPath}' Or '%(NativeInput.FileType)' != 'lib'",
+                        parameters: new Dictionary<string, string>
+                        {
+                            ["Text"] = $"Cargo native project-reference output was not '{publishedPath}' with FileType=lib.",
+                        })
+                .Save()
+                .TryBuild(restore: true, "Build", out bool result, out BuildOutput buildOutput);
+
+            result.ShouldBeTrue(buildOutput.GetConsoleLog());
+            File.ReadAllText(publishedPath).ShouldBe("native import library");
+            File.ReadAllText(consumerOutputPath).ShouldBe("native import library");
         }
 
         [Theory]

--- a/src/Cargo.UnitTests/Microsoft.Build.Cargo.UnitTests.csproj
+++ b/src/Cargo.UnitTests/Microsoft.Build.Cargo.UnitTests.csproj
@@ -29,6 +29,11 @@
     <ProjectReference Include="..\Cargo\Microsoft.Build.Cargo.csproj" ReferenceOutputAssembly="false" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Cargo\CargoArtifactDiscovery.cs" Link="CargoArtifactDiscovery.cs" />
+    <Compile Include="..\Cargo\CargoBuildArguments.cs" Link="CargoBuildArguments.cs" />
+    <Compile Include="..\Cargo\ProcessTreeTermination.cs" Link="ProcessTreeTermination.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <None Include="..\Cargo\sdk\**\*" Link="Sdk\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest">
     </None>
   </ItemGroup>

--- a/src/Cargo/CargoArtifactDiscovery.cs
+++ b/src/Cargo/CargoArtifactDiscovery.cs
@@ -1,0 +1,135 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Json;
+using System.Text;
+
+namespace Microsoft.Build.Cargo
+{
+    internal static class CargoArtifactDiscovery
+    {
+        internal static IReadOnlyList<string> DiscoverPrimaryBuildOutputs(IEnumerable<string> outputLines, string manifestPath)
+        {
+            string normalizedManifestPath = Path.GetFullPath(manifestPath);
+            string manifestDirectory = Path.GetDirectoryName(normalizedManifestPath) ?? throw new InvalidOperationException("Invalid Cargo manifest path.");
+            var outputs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var messageSerializer = new DataContractJsonSerializer(typeof(CargoArtifactMessage));
+
+            foreach (string line in outputLines)
+            {
+                try
+                {
+                    using var stream = new MemoryStream(Encoding.UTF8.GetBytes(line));
+                    var message = (CargoArtifactMessage?)messageSerializer.ReadObject(stream);
+
+                    if (message?.Reason != "compiler-artifact"
+                        || string.IsNullOrEmpty(message.ManifestPath)
+                        || !Path.GetFullPath(message.ManifestPath).Equals(normalizedManifestPath, StringComparison.OrdinalIgnoreCase)
+                        || !IsPublishableTarget(message.Target))
+                    {
+                        continue;
+                    }
+
+                    AddIfFileExists(message.Executable);
+
+                    foreach (string filename in message.Filenames)
+                    {
+                        if (IsPrimaryBuildOutput(filename))
+                        {
+                            AddIfFileExists(filename);
+                        }
+                    }
+                }
+                catch (SerializationException)
+                {
+                    // Cargo can emit non-JSON status lines alongside JSON messages.
+                }
+            }
+
+            foreach (string binary in outputs.ToArray())
+            {
+                string extension = Path.GetExtension(binary);
+                if (extension.Equals(".dll", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddIfFileExists(binary + ".lib");
+                    AddIfFileExists(Path.ChangeExtension(binary, ".lib"));
+                }
+
+                if (extension.Equals(".dll", StringComparison.OrdinalIgnoreCase)
+                    || extension.Equals(".exe", StringComparison.OrdinalIgnoreCase))
+                {
+                    AddIfFileExists(Path.ChangeExtension(binary, ".pdb"));
+                }
+            }
+
+            return outputs.ToArray();
+
+            void AddIfFileExists(string? path)
+            {
+                if (!string.IsNullOrEmpty(path))
+                {
+                    string fullPath = Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(manifestDirectory, path));
+                    if (File.Exists(fullPath))
+                    {
+                        outputs.Add(fullPath);
+                    }
+                }
+            }
+        }
+
+        private static bool IsPublishableTarget(CargoTarget? target)
+        {
+            if (target == null
+                || target.Kind.Any(kind => kind is "custom-build" or "test" or "bench" or "proc-macro"))
+            {
+                return false;
+            }
+
+            return target.Kind.Contains("bin")
+                || target.CrateTypes.Any(crateType => crateType is "cdylib" or "dylib" or "staticlib");
+        }
+
+        private static bool IsPrimaryBuildOutput(string? path)
+        {
+            string extension = Path.GetExtension(path ?? string.Empty).ToLowerInvariant();
+            return extension is ".a" or ".dll" or ".dylib" or ".exe" or ".lib" or ".pdb" or ".so" or ".wasm";
+        }
+
+        [DataContract]
+        private sealed class CargoArtifactMessage
+        {
+            [DataMember(Name = "reason")]
+            public string? Reason { get; set; }
+
+            [DataMember(Name = "manifest_path")]
+            public string? ManifestPath { get; set; }
+
+            [DataMember(Name = "target")]
+            public CargoTarget? Target { get; set; }
+
+            [DataMember(Name = "filenames")]
+            public string[] Filenames { get; set; } = Array.Empty<string>();
+
+            [DataMember(Name = "executable")]
+            public string? Executable { get; set; }
+        }
+
+        [DataContract]
+        private sealed class CargoTarget
+        {
+            [DataMember(Name = "kind")]
+            public string[] Kind { get; set; } = Array.Empty<string>();
+
+            [DataMember(Name = "crate_types")]
+            public string[] CrateTypes { get; set; } = Array.Empty<string>();
+        }
+    }
+}

--- a/src/Cargo/CargoBuildArguments.cs
+++ b/src/Cargo/CargoBuildArguments.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Cargo
+{
+    internal static class CargoBuildArguments
+    {
+        private static readonly Regex MessageFormatRegex = new (
+            @"(?:^|\s)--message-format(?:=|\s+)(?<format>[^\s]+)",
+            RegexOptions.IgnoreCase);
+
+        internal static bool TryEnsureJsonMessageFormat(string arguments, out string effectiveArguments)
+        {
+            MatchCollection matches = MessageFormatRegex.Matches(arguments);
+            if (matches.Count == 0)
+            {
+                effectiveArguments = $"{arguments} --message-format=json-render-diagnostics".Trim();
+                return true;
+            }
+
+            foreach (Match match in matches)
+            {
+                string format = match.Groups["format"].Value.Trim('"', '\'');
+                if (!format.StartsWith("json", StringComparison.OrdinalIgnoreCase))
+                {
+                    effectiveArguments = arguments;
+                    return false;
+                }
+            }
+
+            effectiveArguments = arguments;
+            return true;
+        }
+    }
+}

--- a/src/Cargo/CargoTask.cs
+++ b/src/Cargo/CargoTask.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Build.Cargo
         private static readonly string _loginCommand = "login";
         private static readonly string _rustUpDownloadLink = "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe";
         private static readonly string _checkSumVerifyUrl = "https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe.sha256";
+        private readonly object _logLock = new ();
         private string? _rustUpFile = Environment.GetEnvironmentVariable("MSRUSTUP_FILE");
         private bool _shouldCleanRustPath = false;
         private bool _installationFailure = false;
@@ -115,6 +116,12 @@ namespace Microsoft.Build.Cargo
         /// Use this to enable cross-compilation.
         /// </summary>
         public string MsRustupTargets { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets the primary artifacts produced by a Cargo build.
+        /// </summary>
+        [Output]
+        public ITaskItem[] BuildOutputs { get; private set; } = Array.Empty<ITaskItem>();
 
         /// <inheritdoc/>
         public override bool Execute()
@@ -252,7 +259,20 @@ namespace Microsoft.Build.Cargo
                 Log.LogMessage("'CargoOutputDir' is null or empty. Output directory will be the default Cargo output directory.");
             }
 
+            List<string>? buildOutputLines = null;
+            if (command.Equals("build", StringComparison.OrdinalIgnoreCase))
+            {
+                buildOutputLines = new List<string>();
+                if (!CargoBuildArguments.TryEnsureJsonMessageFormat(args, out args))
+                {
+                    Log.LogError("CargoBuildCommandArgs must use a JSON --message-format so the SDK can discover build outputs.");
+                    return ExitCode.Failed;
+                }
+            }
+
             Log.LogMessage(MessageImportance.Normal, $"Executing cargo command: {command} {args}");
+            Action<string>? buildOutputLineHandler = buildOutputLines == null ? null : buildOutputLines.Add;
+            ExitCode exitCode;
             if (_isMsRustUp)
             {
                 var customCargo = GetCustomToolChainCargoPath();
@@ -260,13 +280,35 @@ namespace Microsoft.Build.Cargo
 
                 if (!string.IsNullOrEmpty(customCargo))
                 {
-                    return await ExecuteProcessAsync(GetCustomToolChainCargoBin() !, $"{command} {args}  --offline {GetMsRustupBuildProfileArgument()} --config {Path.Combine(RepoRoot, _cargoConfigFilePath)}", ".", _envVars);
+                    exitCode = await ExecuteProcessAsync(
+                        GetCustomToolChainCargoBin() !,
+                        $"{command} {args}  --offline {GetMsRustupBuildProfileArgument()} --config {Path.Combine(RepoRoot, _cargoConfigFilePath)}",
+                        ".",
+                        _envVars,
+                        buildOutputLineHandler);
                 }
-
-                return ExitCode.Failed;
+                else
+                {
+                    return ExitCode.Failed;
+                }
+            }
+            else
+            {
+                exitCode = await ExecuteProcessAsync(_cargoPath, $"{command} {args}", ".", _envVars, buildOutputLineHandler);
             }
 
-            return await ExecuteProcessAsync(_cargoPath, $"{command} {args}", ".", _envVars);
+            if (exitCode == ExitCode.Succeeded && buildOutputLines != null)
+            {
+                string manifestPath = Path.Combine(
+                    Directory.GetParent(StartupProj)?.FullName ?? throw new InvalidOperationException("Invalid project path"),
+                    _cargoFileName);
+
+                BuildOutputs = CargoArtifactDiscovery.DiscoverPrimaryBuildOutputs(buildOutputLines, manifestPath)
+                    .Select(path => (ITaskItem)new Microsoft.Build.Utilities.TaskItem(path))
+                    .ToArray();
+            }
+
+            return exitCode;
         }
 
         /// <summary>
@@ -477,7 +519,12 @@ namespace Microsoft.Build.Cargo
             return await ExecuteProcessAsync(_cargoPath, _loginCommand, workingDir);
         }
 
-        private async Task<ExitCode> ExecuteProcessAsync(string fileName, string args, string workingDir, Dictionary<string, string>? envars = null)
+        private async Task<ExitCode> ExecuteProcessAsync(
+            string fileName,
+            string args,
+            string workingDir,
+            Dictionary<string, string>? envars = null,
+            Action<string>? standardOutputLineHandler = null)
         {
             try
             {
@@ -514,19 +561,30 @@ namespace Microsoft.Build.Cargo
                     Log.LogMessage(MessageImportance.Normal, $"\t\t\t\t\t\t*********** Start {nameAndExtension} logs ***********\n\n");
 
                     using StreamReader errReader = process!.StandardError;
-                    _ = Log.LogMessagesFromStream(errReader, MessageImportance.Normal);
-
                     using StreamReader outReader = process!.StandardOutput;
-                    _ = Log.LogMessagesFromStream(outReader, MessageImportance.Normal);
-                    Log.LogMessage(MessageImportance.Normal, $"\t\t\t\t\t\t*********** End {nameAndExtension} logs ***********\n\n");
+                    System.Threading.Tasks.Task errorLoggingTask = LogProcessStreamAsync(errReader);
+                    System.Threading.Tasks.Task outputLoggingTask = LogProcessStreamAsync(outReader, standardOutputLineHandler);
                     bool exited = process.WaitForExit(maxWait);
                     if (!exited)
                     {
-                        process.Kill();
+                        ProcessTreeTermination.Terminate(process, message => Log.LogWarning(message));
+                        if (!process.WaitForExit(30_000))
+                        {
+                            Log.LogWarning($"Process did not exit after its process tree was terminated: '{info.FileName}'.");
+                        }
+
+                        System.Threading.Tasks.Task streamLoggingTask = System.Threading.Tasks.Task.WhenAll(errorLoggingTask, outputLoggingTask);
+                        if (!streamLoggingTask.Wait(30_000))
+                        {
+                            Log.LogWarning($"Process streams did not close after its process tree was terminated: '{info.FileName}'.");
+                        }
+
                         Log.LogError($"Killed process after max timeout reached : '{info.FileName}'");
                         return -1;
                     }
 
+                    System.Threading.Tasks.Task.WhenAll(errorLoggingTask, outputLoggingTask).GetAwaiter().GetResult();
+                    Log.LogMessage(MessageImportance.Normal, $"\t\t\t\t\t\t*********** End {nameAndExtension} logs ***********\n\n");
                     return process.ExitCode;
                 });
 
@@ -538,6 +596,19 @@ namespace Microsoft.Build.Cargo
             {
                 Log.LogWarningFromException(ex);
                 return ExitCode.Failed;
+            }
+        }
+
+        private async System.Threading.Tasks.Task LogProcessStreamAsync(StreamReader reader, Action<string>? lineHandler = null)
+        {
+            string? line;
+            while ((line = await reader.ReadLineAsync()) != null)
+            {
+                lineHandler?.Invoke(line);
+                lock (_logLock)
+                {
+                    Log.LogMessage(MessageImportance.Normal, line);
+                }
             }
         }
 

--- a/src/Cargo/ProcessTreeTermination.cs
+++ b/src/Cargo/ProcessTreeTermination.cs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+
+namespace Microsoft.Build.Cargo
+{
+    internal static class ProcessTreeTermination
+    {
+        internal static void Terminate(Process process, Action<string> logWarning)
+        {
+            try
+            {
+                if (process.HasExited)
+                {
+                    return;
+                }
+
+#if NETFRAMEWORK
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    using Process? taskKill = Process.Start(new ProcessStartInfo
+                    {
+                        FileName = "taskkill.exe",
+                        Arguments = $"/PID {process.Id} /T /F",
+                        CreateNoWindow = true,
+                        UseShellExecute = false,
+                    });
+
+                    if (taskKill == null || !taskKill.WaitForExit(30_000) || taskKill.ExitCode != 0)
+                    {
+                        logWarning($"Could not terminate the complete process tree for process {process.Id}; terminating the parent process.");
+                        process.Kill();
+                    }
+                }
+                else
+                {
+                    process.Kill();
+                }
+#else
+                process.Kill(entireProcessTree: true);
+#endif
+            }
+            catch (InvalidOperationException)
+            {
+                // The process exited while termination was being requested.
+            }
+            catch (Win32Exception ex)
+            {
+                logWarning($"Could not terminate the complete process tree for process {process.Id}: {ex.Message}");
+                if (!process.HasExited)
+                {
+                    process.Kill();
+                }
+            }
+        }
+    }
+}

--- a/src/Cargo/README.md
+++ b/src/Cargo/README.md
@@ -28,6 +28,50 @@ To build a rust project, you can use the following msbuild command:
 msbuild
 ```
 
+### Publishing Cargo build outputs
+
+Cargo keeps its complete target tree under `CargoOutputDir`, which defaults to a `cargo` directory
+under the project's `BaseIntermediateOutputPath`. This follows MSBuild intermediate-output layout,
+including `UseArtifactsOutput`.
+
+`CargoBuild` requests Cargo's JSON message format and discovers primary executable, native-library,
+symbol, and WebAssembly outputs produced by the current `Cargo.toml`. Existing MSVC import libraries
+and PDBs next to a reported DLL are included automatically. The discovered outputs are staged through
+the MSBuild project's `OutputPath`. If `CargoBuildCommandArgs` sets `--message-format`, it must select
+a JSON format. Virtual-workspace roots should use member `.cargoproj` files or explicit
+`CargoBuildOutput` items.
+
+Use `CargoBuildOutput` to add an output Cargo does not report or to override its publication metadata:
+
+```xml
+<ItemGroup>
+  <CargoBuildOutput Include="$(CargoOutputDir)\release\rust_lib_external.dll.lib"
+                    Condition="'$(Configuration)' == 'Release'" />
+</ItemGroup>
+```
+
+After `CargoBuild`, the SDK copies each declared file into the producer's `OutputPath`. The staged
+files are returned through the standard `GetTargetPath` and `GetCopyToOutputDirectoryItems` project
+reference contracts so native link inputs and copy-local consumers use the transferable producer
+output instead of the source-local Cargo tree. Set `TargetPath` to publish an output under a relative
+path or different name, and set `Optional` to `true` when an explicitly declared output may not
+exist. Outputs ending in `.lib` are classified as native libraries for VC++ project references;
+set `FileType` explicitly when another native classification is required:
+
+```xml
+<ItemGroup>
+  <CargoBuildOutput Include="$(CargoOutputDir)\release\rust_lib_external.dll.lib"
+                    TargetPath="native\rust_lib_external.lib" />
+  <CargoBuildOutput Include="$(CargoOutputDir)\release\rust_lib_external.pdb"
+                    Optional="true" />
+</ItemGroup>
+```
+
+Only discovered or declared primary files are published. `CargoOutputDir` remains the Cargo target
+directory, so dependency artifacts and other intermediates are not copied into the shared MSBuild
+output tree. Targets that run after `PublishCargoBuildOutputs` can inspect the staged files through
+`@(CargoPublishedOutput)`.
+
 To clean a rust project, you can use the following msbuild command:
 ```shell
 msbuild /t:clean
@@ -104,4 +148,3 @@ Each value becomes a `--target <triple>` argument. Use this to enable cross-comp
   <MsRustupTargets>aarch64-pc-windows-msvc;x86_64-pc-windows-msvc</MsRustupTargets>
 </PropertyGroup>
 ```
-

--- a/src/Cargo/sdk/Sdk.props
+++ b/src/Cargo/sdk/Sdk.props
@@ -90,7 +90,7 @@
     <RepoRoot Condition="'$(RepoRoot)' == ''">$(EnlistmentRoot)</RepoRoot>
     <CargoInstallationRoot Condition="'$(CargoInstallationRoot)' == ''"></CargoInstallationRoot>
     <MsRustupAuthType Condition="'$(MsRustupAuthType)' == ''">AzureAuth</MsRustupAuthType>
-    <CargoOutputDir Condition="'$(CargoOutputDir)' == ''">$(MSBuildProjectDirectory)\bin</CargoOutputDir>
+    <CargoOutputDir Condition="'$(CargoOutputDir)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(BaseIntermediateOutputPath)', 'cargo'))</CargoOutputDir>
     <!--
       Optional CargoBuild profile override, e.g. "release-windows".
       When set, the SDK passes the value as the Cargo "profile" argument, instead of deriving the profile from Configuration.

--- a/src/Cargo/sdk/Sdk.targets
+++ b/src/Cargo/sdk/Sdk.targets
@@ -53,6 +53,13 @@
 
     <!-- Don't emit a reference assembly -->
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
+
+    <GetCopyToOutputDirectoryItemsDependsOn>
+      _AddCargoPublishedOutputsToContentItems;
+      $(GetCopyToOutputDirectoryItemsDependsOn)
+    </GetCopyToOutputDirectoryItemsDependsOn>
+
+    <_CargoBuildOutputsCacheFile>$(IntermediateOutputPath)Microsoft.Build.Cargo.outputs</_CargoBuildOutputsCacheFile>
   </PropertyGroup>
 
   <!-- Clear output group items which are read by the IDE and NuGet. -->
@@ -70,15 +77,24 @@
   -->
   <Target Name="ComputeIntermediateSatelliteAssemblies" />
 
-  <!--
-    Cargo projects do not build an assembly so dependent projects shouldn't get a path to the target.  Override the GetTargetPath to do nothing.
-  -->
-  <Target Name="GetTargetPath" />
+  <Target Name="GetTargetPath"
+          DependsOnTargets="GetTargetPathWithTargetPlatformMoniker"
+          Returns="@(TargetPathWithTargetPlatformMoniker)" />
 
-  <!--
-    The GetTargetPathWithTargetPlatformMoniker target uses a BeforeTargets so the only way to disable it is to override it with an empty target.
-  -->
-  <Target Name="GetTargetPathWithTargetPlatformMoniker" />
+  <Target Name="GetTargetPathWithTargetPlatformMoniker"
+          DependsOnTargets="_ComputeCargoPublishedOutputs"
+          Returns="@(TargetPathWithTargetPlatformMoniker)">
+    <ItemGroup>
+      <TargetPathWithTargetPlatformMoniker Include="@(CargoPublishedOutput)"
+                                           Condition="'%(CargoPublishedOutput.Optional)' != 'true' Or Exists('%(CargoPublishedOutput.FullPath)')">
+        <FileType>%(CargoPublishedOutput.FileType)</FileType>
+        <TargetPlatformMoniker>$(TargetPlatformMoniker)</TargetPlatformMoniker>
+        <TargetPlatformIdentifier>$(TargetPlatformIdentifier)</TargetPlatformIdentifier>
+        <TargetFrameworkIdentifier>$(TargetFrameworkIdentifier)</TargetFrameworkIdentifier>
+        <TargetFrameworkVersion>$(TargetFrameworkVersion.TrimStart('vV'))</TargetFrameworkVersion>
+      </TargetPathWithTargetPlatformMoniker>
+    </ItemGroup>
+  </Target>
 
   <!--
     The GetReferenceAssemblyPaths does not need to run since reference assemblies aren't needed.
@@ -119,7 +135,9 @@
     <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="fetch"  RepoRoot="$(RepoRoot)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
   </Target>
   <Target Name="CargoBuild" AfterTargets="CoreCompile">
-    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build" CommandArgs="$(CargoBuildCommandArgs)" Configuration="$(Configuration)" RepoRoot="$(RepoRoot)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" MsRustupCargoProfile="$(MsRustupCargoProfile)" />
+    <CargoTask EnableAuth="$(AuthMode)" StartupProj="$(StartupProj)" Command="build" CommandArgs="$(CargoBuildCommandArgs)" Configuration="$(Configuration)" RepoRoot="$(RepoRoot)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" MsRustupCargoProfile="$(MsRustupCargoProfile)">
+      <Output TaskParameter="BuildOutputs" ItemName="_DiscoveredCargoBuildOutput" />
+    </CargoTask>
   </Target>
   <Target Name="CargoTest" DependsOnTargets="CargoFetch">
     <CargoTask StartupProj="$(StartupProj)" Command="test" CommandArgs="$(CargoTestCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
@@ -144,5 +162,125 @@
   </Target>
   <Target Name="ClearCargoCache">
     <CargoTask StartupProj="$(StartupProj)" Command="clearcargocache" CommandArgs="$(ClearCargoCacheCommandArgs)" CargoInstallationRoot="$(CargoInstallationRoot)" MsRustupAuthType="$(MsRustupAuthType)" CargoOutputDir="$(CargoOutputDir)" />
+  </Target>
+
+  <!-- Cargo build output publication -->
+  <Target Name="_PrepareDiscoveredCargoBuildOutputs"
+          AfterTargets="CargoBuild">
+    <ItemGroup>
+      <_DiscoveredCargoBuildOutput Remove="@(CargoBuildOutput)"
+                                   MatchOnMetadata="FullPath"
+                                   MatchOnMetadataOptions="PathLike" />
+      <CargoBuildOutput Include="@(_DiscoveredCargoBuildOutput)">
+        <AutomaticallyDiscovered>true</AutomaticallyDiscovered>
+      </CargoBuildOutput>
+    </ItemGroup>
+    <Delete Files="$(_CargoBuildOutputsCacheFile)"
+            Condition="Exists('$(_CargoBuildOutputsCacheFile)')" />
+  </Target>
+
+  <Target Name="_LoadCachedCargoBuildOutputs"
+          Condition="Exists('$(_CargoBuildOutputsCacheFile)')">
+    <ReadLinesFromFile File="$(_CargoBuildOutputsCacheFile)">
+      <Output TaskParameter="Lines" ItemName="_CachedCargoPublishedOutput" />
+    </ReadLinesFromFile>
+    <ItemGroup>
+      <_CachedCargoPublishedOutput Remove="@(_CachedCargoPublishedOutput)"
+                                   Condition="!Exists('%(FullPath)')" />
+      <_CachedCargoPublishedOutput>
+        <AutomaticallyDiscovered>true</AutomaticallyDiscovered>
+        <FileType Condition="'%(Extension)' == '.lib'">lib</FileType>
+        <TargetPath>%(Filename)%(Extension)</TargetPath>
+      </_CachedCargoPublishedOutput>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_ComputeCargoPublishedOutputs"
+          DependsOnTargets="_LoadCachedCargoBuildOutputs"
+          Condition="'@(CargoBuildOutput)' != '' Or Exists('$(_CargoBuildOutputsCacheFile)')">
+    <PropertyGroup>
+      <_CargoPublishOutputPath>$([MSBuild]::NormalizeDirectory('$(MSBuildProjectDirectory)', '$(OutDir)'))</_CargoPublishOutputPath>
+    </PropertyGroup>
+    <ItemGroup>
+      <_CargoBuildOutput Include="@(CargoBuildOutput)">
+        <FileType Condition="'%(CargoBuildOutput.FileType)' == '' And '%(CargoBuildOutput.Extension)' == '.lib'">lib</FileType>
+        <TargetPath Condition="'%(CargoBuildOutput.TargetPath)' == ''">%(CargoBuildOutput.Filename)%(CargoBuildOutput.Extension)</TargetPath>
+      </_CargoBuildOutput>
+      <_ComputedCargoPublishedOutput Include="@(_CargoBuildOutput->'$(_CargoPublishOutputPath)%(TargetPath)')">
+        <AutomaticallyDiscovered>%(_CargoBuildOutput.AutomaticallyDiscovered)</AutomaticallyDiscovered>
+        <FileType>%(_CargoBuildOutput.FileType)</FileType>
+        <Optional>%(_CargoBuildOutput.Optional)</Optional>
+        <SourcePath>%(_CargoBuildOutput.FullPath)</SourcePath>
+        <TargetPath>%(_CargoBuildOutput.TargetPath)</TargetPath>
+      </_ComputedCargoPublishedOutput>
+      <_CachedCargoPublishedOutput Remove="@(_ComputedCargoPublishedOutput)"
+                                   MatchOnMetadata="FullPath"
+                                   MatchOnMetadataOptions="PathLike" />
+      <CargoPublishedOutput Include="@(_ComputedCargoPublishedOutput);@(_CachedCargoPublishedOutput)" />
+    </ItemGroup>
+
+    <Error Text="Cargo build output TargetPath '%(CargoPublishedOutput.TargetPath)' must remain under '$(OutDir)'."
+           Condition="$([System.IO.Path]::IsPathRooted('%(CargoPublishedOutput.TargetPath)')) Or $([System.Text.RegularExpressions.Regex]::IsMatch('%(CargoPublishedOutput.TargetPath)', '(^|[\\/])\.\.([\\/]|$)'))" />
+  </Target>
+
+  <Target Name="PublishCargoBuildOutputs"
+          AfterTargets="_PrepareDiscoveredCargoBuildOutputs"
+          DependsOnTargets="_ComputeCargoPublishedOutputs"
+          Condition="'@(CargoBuildOutput)' != ''">
+    <ItemGroup>
+      <_CargoBuildOutputToPublish Include="@(_CargoBuildOutput)"
+                                  Condition="Exists('%(FullPath)')" />
+      <_StaleOptionalCargoPublishedOutput Include="@(CargoPublishedOutput)"
+                                          Condition="'%(Optional)' == 'true' And !Exists('%(SourcePath)') And Exists('%(FullPath)')" />
+    </ItemGroup>
+
+    <Error Text="Cargo build output '%(CargoBuildOutput.Identity)' does not exist."
+           Condition="'%(CargoBuildOutput.Optional)' != 'true' And !Exists('%(CargoBuildOutput.FullPath)')" />
+
+    <Delete Files="@(_StaleOptionalCargoPublishedOutput)" />
+
+    <Copy SourceFiles="@(_CargoBuildOutputToPublish)"
+          DestinationFiles="@(_CargoBuildOutputToPublish->'$(_CargoPublishOutputPath)%(TargetPath)')"
+          SkipUnchangedFiles="true"
+          OverwriteReadOnlyFiles="$(OverwriteReadOnlyFiles)"
+          Retries="$(CopyRetryCount)"
+          RetryDelayMilliseconds="$(CopyRetryDelayMilliseconds)">
+      <Output TaskParameter="DestinationFiles" ItemName="FileWrites" />
+    </Copy>
+
+    <ItemGroup>
+      <_DiscoveredCargoPublishedOutputToCache Include="@(CargoPublishedOutput)"
+                                              Condition="'%(AutomaticallyDiscovered)' == 'true' And Exists('%(FullPath)')" />
+      <FileWrites Include="$(_CargoBuildOutputsCacheFile)"
+                  Condition="'@(_DiscoveredCargoPublishedOutputToCache)' != ''" />
+    </ItemGroup>
+    <WriteLinesToFile File="$(_CargoBuildOutputsCacheFile)"
+                      Lines="@(_DiscoveredCargoPublishedOutputToCache)"
+                      Overwrite="true"
+                      WriteOnlyWhenDifferent="true"
+                      Condition="'@(_DiscoveredCargoPublishedOutputToCache)' != ''" />
+  </Target>
+
+  <Target Name="_AddCargoPublishedOutputsToContentItems"
+          DependsOnTargets="_ComputeCargoPublishedOutputs"
+          Condition="'@(CargoBuildOutput)' != '' Or Exists('$(_CargoBuildOutputsCacheFile)')">
+    <ItemGroup>
+      <ContentWithTargetPath Include="@(CargoPublishedOutput)"
+                             Condition="Exists('%(FullPath)')">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <TargetPath>%(CargoPublishedOutput.TargetPath)</TargetPath>
+      </ContentWithTargetPath>
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_RemoveCargoPublishedOutputsFromLocalCopyItems"
+          BeforeTargets="_CopyOutOfDateSourceItemsToOutputDirectory;_CopyOutOfDateSourceItemsToOutputDirectoryAlways;_CopyDifferingSourceItemsToOutputDirectory"
+          Condition="'@(CargoPublishedOutput)' != ''">
+    <ItemGroup>
+      <_CargoPublishedOutputFullPath Include="@(CargoPublishedOutput->'%(FullPath)')" />
+      <_SourceItemsToCopyToOutputDirectory Remove="@(_CargoPublishedOutputFullPath)" />
+      <_SourceItemsToCopyToOutputDirectoryAlways Remove="@(_CargoPublishedOutputFullPath)" />
+      <_SourceItemsToCopyToOutputDirectoryIfDifferent Remove="@(_CargoPublishedOutputFullPath)" />
+    </ItemGroup>
   </Target>
 </Project>


### PR DESCRIPTION
## Summary

This updates the Cargo SDK so generated primary outputs are published through the evaluated MSBuild `OutputPath` instead of staying only in Cargo’s target tree. That lets dependent projects consume Rust-produced artifacts through normal MSBuild project-reference contracts while keeping Cargo intermediates out of the public output directory.

The SDK still honors `CargoOutputDir` overrides and ordinary local Cargo builds. The new contract also supports explicit output declarations and automatic discovery for the common cases the SDK can safely publish.

## Why this is safe

- Cargo’s full target/intermediate tree still stays under the Cargo output directory; only selected primary outputs are staged for MSBuild consumption.
- Explicit output items override discovery, so unusual or renamed outputs can be declared without changing the default behavior.
- The publication point is integrated so outputs exist before project completion and are visible to downstream project-reference consumers.
- Package/native consumer behavior was verified, including a real VC++ project-reference scenario using a staged import library.

## Validation

| Test / build | Result |
|---|---|
| `src/Cargo/Microsoft.Build.Cargo.csproj` Release build | pass |
| Cargo unit test matrix | 280/280 passed |
| Packaged fake-Cargo integration | pass |
| Real VC++ project-reference consumer | pass |
| High-volume stream + process-tree timeout coverage | pass |
| Incremental + clean validation | pass |

## Out of scope

- This does not move the full Cargo target tree into `OutputPath`.
- This does not change downstream sample/workaround projects beyond the SDK contract itself.
