### PR TITLE
Validate MSRustup feed URLs

### DIFF
--- a/src/Cargo.UnitTests/Microsoft.Build.Cargo.UnitTests.csproj
+++ b/src/Cargo.UnitTests/Microsoft.Build.Cargo.UnitTests.csproj
@@ -31,9 +31,11 @@
   <ItemGroup>
     <Compile Include="..\Cargo\CargoArtifactDiscovery.cs" Link="CargoArtifactDiscovery.cs" />
     <Compile Include="..\Cargo\CargoBuildArguments.cs" Link="CargoBuildArguments.cs" />
+    <Compile Include="..\Cargo\MsRustupFeedUrl.cs" Link="MsRustupFeedUrl.cs" />
     <Compile Include="..\Cargo\ProcessTreeTermination.cs" Link="ProcessTreeTermination.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\Cargo\dist\msrustup.ps1" Link="msrustup.ps1" CopyToOutputDirectory="PreserveNewest" />
     <None Include="..\Cargo\sdk\**\*" Link="Sdk\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest">
     </None>
   </ItemGroup>

--- a/src/Cargo.UnitTests/MsRustupFeedUrlTests.cs
+++ b/src/Cargo.UnitTests/MsRustupFeedUrlTests.cs
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Shouldly;
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Microsoft.Build.Cargo.UnitTests
+{
+    public class MsRustupFeedUrlTests
+    {
+        [Theory]
+        [InlineData(
+            "sparse+https://mscodehub.pkgs.visualstudio.com/Rust/_packaging/Rust%40Release/Cargo/index",
+            "mscodehub")]
+        [InlineData(
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/Cargo/index/",
+            "dnceng")]
+        public void CreatesNuGetFeedFromTrustedCargoRegistry(string registryUrl, string expectedOrganization)
+        {
+            MsRustupFeedUrl.TryCreateFromCargoRegistry(registryUrl, out string feedUrl, out string error)
+                .ShouldBeTrue(error);
+
+            feedUrl.ShouldEndWith("/nuget/v3/index.json");
+            MsRustupFeedUrl.TryValidateAzureArtifactsUri(feedUrl, out _, out string organization, out error)
+                .ShouldBeTrue(error);
+            organization.ShouldBe(expectedOrganization);
+        }
+
+        [Theory]
+        [InlineData("https://attacker.example/_packaging/feed/Cargo/index")]
+        [InlineData("https://mscodehub.pkgs.visualstudio.com.attacker.example/_packaging/feed/Cargo/index")]
+        [InlineData("http://mscodehub.pkgs.visualstudio.com/_packaging/feed/Cargo/index")]
+        [InlineData("https://user@mscodehub.pkgs.visualstudio.com/_packaging/feed/Cargo/index")]
+        [InlineData("https://mscodehub.pkgs.visualstudio.com:444/_packaging/feed/Cargo/index")]
+        [InlineData("https://bad.org.pkgs.visualstudio.com/_packaging/feed/Cargo/index")]
+        [InlineData("https://pkgs.dev.azure.com/dnceng/_packaging/feed/Cargo/index?redirect=attacker")]
+        [InlineData("https://pkgs.dev.azure.com/dnceng/_packaging/feed/nuget/v3/index.json")]
+        [InlineData("https://pkgs.dev.azure.com/dnceng/Cargo/index")]
+        public void RejectsUntrustedCargoRegistry(string registryUrl)
+        {
+            MsRustupFeedUrl.TryCreateFromCargoRegistry(registryUrl, out _, out string error).ShouldBeFalse();
+            error.ShouldNotBeNullOrWhiteSpace();
+        }
+
+        [Theory]
+        [InlineData(
+            "https://mscodehub.pkgs.visualstudio.com/Rust/_packaging/Rust%40Release/nuget/v3/index.json",
+            "mscodehub")]
+        [InlineData(
+            "https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json",
+            "dnceng")]
+        public void PowerShellAcceptsTrustedServiceIndexes(string feedUrl, string expectedOrganization)
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                return;
+            }
+
+            ProcessResult result = RunPowerShell(
+                $"$uri = Resolve-TrustedAzureArtifactsUri -Value '{feedUrl}' -Description 'test' -RequireServiceIndex; " +
+                "Get-AzureArtifactsOrganization -Uri $uri");
+
+            result.ExitCode.ShouldBe(0, result.Output);
+            result.Output.Trim().ShouldBe(expectedOrganization);
+        }
+
+        [Theory]
+        [InlineData(
+            "https://mscodehub.pkgs.visualstudio.com/Rust/_packaging/Rust%40Release/nuget/v3/flat2/",
+            "mscodehub")]
+        [InlineData(
+            "https://pkgs.dev.azure.com/mscodehub/project-id/_packaging/feed-id/nuget/v3/flat2/",
+            "mscodehub")]
+        public void PowerShellAcceptsSameOrganizationPackageBases(string packageBaseUrl, string expectedOrganization)
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                return;
+            }
+
+            ProcessResult result = RunPowerShell(
+                $"Resolve-TrustedAzureArtifactsUri -Value '{packageBaseUrl}' -Description 'test' " +
+                $"-ExpectedOrganization '{expectedOrganization}' -RequirePackageBase | Out-Null");
+
+            result.ExitCode.ShouldBe(0, result.Output);
+        }
+
+        [Theory]
+        [InlineData("http://mscodehub.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json", "")]
+        [InlineData("https://attacker.example/_packaging/feed/nuget/v3/index.json", "")]
+        [InlineData("https://mscodehub.pkgs.visualstudio.com.attacker.example/_packaging/feed/nuget/v3/index.json", "")]
+        [InlineData("https://user@mscodehub.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json", "")]
+        [InlineData("https://mscodehub.pkgs.visualstudio.com:444/_packaging/feed/nuget/v3/index.json", "")]
+        [InlineData("https://pkgs.dev.azure.com/other/project/_packaging/feed/nuget/v3/flat2/", "mscodehub")]
+        public void PowerShellRejectsUntrustedAuthenticatedDestinations(string url, string expectedOrganization)
+        {
+            if (Environment.OSVersion.Platform != PlatformID.Win32NT)
+            {
+                return;
+            }
+
+            string expectedOrganizationArgument = string.IsNullOrEmpty(expectedOrganization)
+                ? string.Empty
+                : $" -ExpectedOrganization '{expectedOrganization}'";
+            ProcessResult result = RunPowerShell(
+                $"Resolve-TrustedAzureArtifactsUri -Value '{url}' -Description 'test'{expectedOrganizationArgument} | Out-Null");
+
+            result.ExitCode.ShouldNotBe(0, result.Output);
+        }
+
+        [Fact]
+        public void CredentialedRequestsRejectRedirects()
+        {
+            string script = File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "msrustup.ps1"));
+            MatchCollection authenticatedRequests = Regex.Matches(
+                script,
+                @"Invoke-(?:RestMethod|WebRequest)[^\r\n]*-Headers \$h[^\r\n]*");
+
+            authenticatedRequests.Count.ShouldBe(3);
+            authenticatedRequests.Cast<Match>().ShouldAllBe(match =>
+                match.Value.IndexOf("-MaximumRedirection 0", StringComparison.Ordinal) >= 0);
+        }
+
+        private static ProcessResult RunPowerShell(string command)
+        {
+            string scriptPath = Path.Combine(AppContext.BaseDirectory, "msrustup.ps1").Replace("'", "''");
+            using var process = Process.Start(new ProcessStartInfo
+            {
+                FileName = "powershell.exe",
+                Arguments = $"-NoProfile -NonInteractive -ExecutionPolicy Bypass -Command \"& {{ $ErrorActionPreference = 'Stop'; . '{scriptPath}'; {command} }}\"",
+                CreateNoWindow = true,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true,
+                UseShellExecute = false,
+            });
+
+            process.ShouldNotBeNull();
+            string output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+            process.WaitForExit();
+            return new ProcessResult(process.ExitCode, output);
+        }
+
+        private sealed class ProcessResult
+        {
+            public ProcessResult(int exitCode, string output)
+            {
+                ExitCode = exitCode;
+                Output = output;
+            }
+
+            public int ExitCode { get; }
+
+            public string Output { get; }
+        }
+    }
+}

--- a/src/Cargo/CargoTask.cs
+++ b/src/Cargo/CargoTask.cs
@@ -669,17 +669,16 @@ namespace Microsoft.Build.Cargo
                     KeyValuePair<string, string>? feedUrl = feedUrls.FirstOrDefault();
                     if (feedUrl.HasValue)
                     {
-                        string transformedFeedUrl = string.Empty;
                         if (string.IsNullOrEmpty(feedUrl.Value.Value))
                         {
                             Log.LogWarning("No valid nuget feed URL found in the cargo config file.");
                             return false;
                         }
 
-                        var match = Regex.Match(feedUrl.Value.Value, @"^(?:sparse\+)?(.*?)/Cargo/index/?$", RegexOptions.IgnoreCase);
-                        if (match.Success)
+                        if (!MsRustupFeedUrl.TryCreateFromCargoRegistry(feedUrl.Value.Value, out string transformedFeedUrl, out string error))
                         {
-                            transformedFeedUrl = $"{match.Groups[1].Value}/nuget/v3/index.json";
+                            Log.LogError($"The MSRustup Cargo registry URL is not trusted: {error}");
+                            return false;
                         }
 
                         AddOrUpdateEnvVar("MSRUSTUP_FEED_URL", transformedFeedUrl);

--- a/src/Cargo/MsRustupFeedUrl.cs
+++ b/src/Cargo/MsRustupFeedUrl.cs
@@ -1,0 +1,133 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// Licensed under the MIT license.
+
+#nullable enable
+
+using System;
+using System.Text.RegularExpressions;
+
+namespace Microsoft.Build.Cargo
+{
+    internal static class MsRustupFeedUrl
+    {
+        private const string AzureArtifactsHost = "pkgs.dev.azure.com";
+        private const string LegacyAzureArtifactsHostSuffix = ".pkgs.visualstudio.com";
+        private const string CargoIndexSuffix = "/Cargo/index";
+        private const string NuGetIndexSuffix = "/nuget/v3/index.json";
+
+        public static bool TryCreateFromCargoRegistry(string registryUrl, out string feedUrl, out string error)
+        {
+            feedUrl = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(registryUrl))
+            {
+                error = "The Cargo registry URL is empty.";
+                return false;
+            }
+
+            const string sparsePrefix = "sparse+";
+            string url = registryUrl.StartsWith(sparsePrefix, StringComparison.OrdinalIgnoreCase)
+                ? registryUrl.Substring(sparsePrefix.Length)
+                : registryUrl;
+
+            if (!TryValidateAzureArtifactsUri(url, out Uri registryUri, out _, out error))
+            {
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(registryUri.Query) || !string.IsNullOrEmpty(registryUri.Fragment))
+            {
+                error = "The Cargo registry URL cannot contain a query string or fragment.";
+                return false;
+            }
+
+            string path = registryUri.AbsolutePath.TrimEnd('/');
+            if (!path.EndsWith(CargoIndexSuffix, StringComparison.OrdinalIgnoreCase)
+                || path.IndexOf("/_packaging/", StringComparison.OrdinalIgnoreCase) < 0)
+            {
+                error = $"The Cargo registry URL must be an Azure Artifacts Cargo index ending in '{CargoIndexSuffix}'.";
+                return false;
+            }
+
+            var feedUri = new UriBuilder(registryUri)
+            {
+                Path = path.Substring(0, path.Length - CargoIndexSuffix.Length) + NuGetIndexSuffix,
+                Query = string.Empty,
+                Fragment = string.Empty,
+            };
+
+            feedUrl = feedUri.Uri.AbsoluteUri;
+            error = string.Empty;
+            return true;
+        }
+
+        internal static bool TryValidateAzureArtifactsUri(
+            string value,
+            out Uri uri,
+            out string organization,
+            out string error)
+        {
+            organization = string.Empty;
+
+            if (!Uri.TryCreate(value, UriKind.Absolute, out Uri? parsedUri))
+            {
+                uri = null!;
+                error = "The URL must be an absolute URI.";
+                return false;
+            }
+
+            uri = parsedUri;
+
+            if (!uri.Scheme.Equals(Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                error = "The URL must use HTTPS.";
+                return false;
+            }
+
+            if (uri.Port != 443)
+            {
+                error = "The URL must use port 443.";
+                return false;
+            }
+
+            if (!string.IsNullOrEmpty(uri.UserInfo))
+            {
+                error = "The URL cannot contain user information.";
+                return false;
+            }
+
+            string host = uri.DnsSafeHost;
+            if (host.Equals(AzureArtifactsHost, StringComparison.OrdinalIgnoreCase))
+            {
+                string[] segments = uri.AbsolutePath.Split(new[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                if (segments.Length == 0)
+                {
+                    error = $"The URL must identify an Azure DevOps organization on '{AzureArtifactsHost}'.";
+                    return false;
+                }
+
+                organization = Uri.UnescapeDataString(segments[0]);
+            }
+            else if (host.EndsWith(LegacyAzureArtifactsHostSuffix, StringComparison.OrdinalIgnoreCase)
+                && host.Length > LegacyAzureArtifactsHostSuffix.Length)
+            {
+                organization = host.Substring(0, host.Length - LegacyAzureArtifactsHostSuffix.Length);
+            }
+            else
+            {
+                error = "The URL host must be a Microsoft-hosted Azure Artifacts endpoint.";
+                return false;
+            }
+
+            if (!Regex.IsMatch(organization, "^[a-z0-9][a-z0-9-]*$", RegexOptions.IgnoreCase))
+            {
+                error = "The URL contains an invalid Azure DevOps organization name.";
+                return false;
+            }
+
+            error = string.Empty;
+            return true;
+        }
+    }
+}

--- a/src/Cargo/README.md
+++ b/src/Cargo/README.md
@@ -126,6 +126,15 @@ msbuild /t:clearcargocache
  channel = "ms-<version>"
  ```
 
+The authenticated MSRustup download supports Microsoft-hosted Azure Artifacts feeds in either of these forms:
+
+```text
+https://<organization>.pkgs.visualstudio.com/...
+https://pkgs.dev.azure.com/<organization>/...
+```
+
+For security, feed and package URLs must use HTTPS on port 443 without embedded credentials. Package URLs returned by the feed must remain in the same Azure DevOps organization, and authenticated redirects are rejected.
+
 #### Optional MSRustup configuration properties
 
  The SDK exposes a handful of MSBuild properties for advanced scenarios.

--- a/src/Cargo/dist/msrustup.ps1
+++ b/src/Cargo/dist/msrustup.ps1
@@ -15,6 +15,101 @@ param (
 
 $ErrorActionPreference = "Stop"
 
+function Get-AzureArtifactsOrganization {
+    param (
+        [Parameter(Mandatory = $true)]
+        [Uri]$Uri
+    )
+
+    $hostName = $Uri.DnsSafeHost.ToLowerInvariant()
+    if ($hostName -eq 'pkgs.dev.azure.com') {
+        $segments = $Uri.AbsolutePath.Split(
+            [char[]]'/', [System.StringSplitOptions]::RemoveEmptyEntries)
+        if ($segments.Length -eq 0) {
+            throw "The URL must identify an Azure DevOps organization on 'pkgs.dev.azure.com'."
+        }
+
+        $organization = [Uri]::UnescapeDataString($segments[0])
+    } else {
+        $legacySuffix = '.pkgs.visualstudio.com'
+        if (-not $hostName.EndsWith($legacySuffix, [StringComparison]::OrdinalIgnoreCase) -or
+            $hostName.Length -le $legacySuffix.Length) {
+            throw "The URL host must be a Microsoft-hosted Azure Artifacts endpoint."
+        }
+
+        $organization = $hostName.Substring(0, $hostName.Length - $legacySuffix.Length)
+    }
+
+    if ($organization -notmatch '^[a-z0-9][a-z0-9-]*$') {
+        throw "The URL contains an invalid Azure DevOps organization name."
+    }
+
+    return $organization
+}
+
+function Resolve-TrustedAzureArtifactsUri {
+    param (
+        [Parameter(Mandatory = $true)]
+        [string]$Value,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Description,
+
+        [string]$ExpectedOrganization,
+
+        [switch]$RequireServiceIndex,
+
+        [switch]$RequirePackageBase
+    )
+
+    $uri = $null
+    if (-not [Uri]::TryCreate($Value, [UriKind]::Absolute, [ref]$uri)) {
+        throw "$Description must be an absolute URI."
+    }
+
+    if ($uri.Scheme -ne [Uri]::UriSchemeHttps) {
+        throw "$Description must use HTTPS."
+    }
+
+    if ($uri.Port -ne 443) {
+        throw "$Description must use port 443."
+    }
+
+    if (-not [string]::IsNullOrEmpty($uri.UserInfo)) {
+        throw "$Description cannot contain user information."
+    }
+
+    if (-not [string]::IsNullOrEmpty($uri.Query) -or -not [string]::IsNullOrEmpty($uri.Fragment)) {
+        throw "$Description cannot contain a query string or fragment."
+    }
+
+    $organization = Get-AzureArtifactsOrganization -Uri $uri
+    if (-not [string]::IsNullOrEmpty($ExpectedOrganization) -and
+        -not $organization.Equals($ExpectedOrganization, [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Description must belong to the same Azure DevOps organization as the feed."
+    }
+
+    if ($uri.AbsolutePath.IndexOf('/_packaging/', [StringComparison]::OrdinalIgnoreCase) -lt 0) {
+        throw "$Description must identify an Azure Artifacts feed."
+    }
+
+    if ($RequireServiceIndex -and
+        -not $uri.AbsolutePath.EndsWith('/nuget/v3/index.json', [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Description must identify a NuGet v3 service index."
+    }
+
+    if ($RequirePackageBase -and
+        -not $uri.AbsolutePath.EndsWith('/nuget/v3/flat2/', [StringComparison]::OrdinalIgnoreCase)) {
+        throw "$Description must identify an Azure Artifacts NuGet package base."
+    }
+
+    return $uri
+}
+
+if ($MyInvocation.InvocationName -eq '.') {
+    return
+}
+
  # Create directory if it doesn't exist
     Write-Host $destinationDirectory
     if (-Not (Test-Path $destinationDirectory)) {
@@ -45,10 +140,18 @@ Switch ([System.Runtime.InteropServices.RuntimeInformation,mscorlib]::OSArchitec
 $package = "rust.msrustup-$target_arch-$target_rest"
 
 # Feed configuration
-$feed = if (Test-Path env:MSRUSTUP_FEED_URL) {
+$feedValue = if (Test-Path env:MSRUSTUP_FEED_URL) {
     $env:MSRUSTUP_FEED_URL
 } else {
     'https://mscodehub.pkgs.visualstudio.com/Rust/_packaging/Rust%40Release/nuget/v3/index.json'
+}
+
+try {
+    $feed = Resolve-TrustedAzureArtifactsUri -Value $feedValue -Description 'The MSRustup feed URL' -RequireServiceIndex
+    $feedOrganization = Get-AzureArtifactsOrganization -Uri $feed
+} catch {
+    Write-Error "Invalid MSRustup feed URL. $($_.Exception.Message)"
+    exit 1
 }
 
 # Get authentication token
@@ -82,12 +185,32 @@ elseif ((Get-Command "azureauth" -ErrorAction SilentlyContinue) -ne $null) {
 $h = @{'Authorization' = "$token"}
 try {
     # Download latest NuGet package
-    $response = Invoke-RestMethod -Headers $h $feed
-    $base = ($response.resources | Where-Object { $_.'@type' -eq 'PackageBaseAddress/3.0.0' }).'@id'
-    $version = (Invoke-RestMethod -Headers $h "$base/$package/index.json").versions[0]
-    Invoke-WebRequest -Headers $h "${base}${package}/$version/$package.$version.nupkg" -OutFile 'msrustup.zip'
+    $response = Invoke-RestMethod -UseBasicParsing -MaximumRedirection 0 -Headers $h -Uri $feed
+    $packageBaseResources = @($response.resources | Where-Object { $_.'@type' -eq 'PackageBaseAddress/3.0.0' })
+    if ($packageBaseResources.Count -ne 1) {
+        throw "The MSRustup feed must provide exactly one NuGet package base."
+    }
+
+    $base = Resolve-TrustedAzureArtifactsUri `
+        -Value $packageBaseResources[0].'@id' `
+        -Description 'The MSRustup package base URL' `
+        -ExpectedOrganization $feedOrganization `
+        -RequirePackageBase
+
+    $packageIndex = Resolve-TrustedAzureArtifactsUri `
+        -Value ([Uri]::new($base, "$package/index.json").AbsoluteUri) `
+        -Description 'The MSRustup package index URL' `
+        -ExpectedOrganization $feedOrganization
+
+    $version = (Invoke-RestMethod -UseBasicParsing -MaximumRedirection 0 -Headers $h -Uri $packageIndex).versions[0]
+    $packageDownload = Resolve-TrustedAzureArtifactsUri `
+        -Value ([Uri]::new($base, "$package/$version/$package.$version.nupkg").AbsoluteUri) `
+        -Description 'The MSRustup package download URL' `
+        -ExpectedOrganization $feedOrganization
+
+    Invoke-WebRequest -UseBasicParsing -MaximumRedirection 0 -Headers $h -Uri $packageDownload -OutFile 'msrustup.zip'
 } catch {
-    Write-Error "Failed to download msrustup package. Please check your access token and feed URL."
+    Write-Error "Failed to download msrustup package. $($_.Exception.Message)"
     exit 1
 }
 


### PR DESCRIPTION
## Summary
- validate MSRustup registry, feed, and package URLs against supported Azure Artifacts formats
- keep package requests within the configured Azure DevOps organization and use strict redirect handling
- add focused URL validation tests and document the supported feed forms

## Testing
- dotnet test src\Cargo.UnitTests\Microsoft.Build.Cargo.UnitTests.csproj -f net8.0 --no-restore
- dotnet build src\Cargo\Microsoft.Build.Cargo.csproj -c Release --no-restore